### PR TITLE
Version 1.1

### DIFF
--- a/src/PixiParser.Benchmarks/Benchmarks/DeserializationBenchmarks.cs
+++ b/src/PixiParser.Benchmarks/Benchmarks/DeserializationBenchmarks.cs
@@ -1,0 +1,32 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace PixiEditor.Parser.Benchmarks
+{
+    [SimpleJob(RuntimeMoniker.NetCoreApp50, baseline: true)]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    [HtmlExporter]
+    [MarkdownExporterAttribute.GitHub]
+    public class DeserializationBenchmarks
+    {
+        private byte[] benchmarkDocument;
+
+        [Params(32, 64, 1920)]
+        public int Size;
+
+        [Params(1, 4)]
+        public int Layers;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            benchmarkDocument = PixiParser.Serialize(Helper.CreateDocument(Size, Layers));
+        }
+
+        [Benchmark]
+        public void Deserialize()
+        {
+            PixiParser.Deserialize(benchmarkDocument);
+        }
+    }
+}

--- a/src/PixiParser.Benchmarks/Benchmarks/DeserializationBenchmarks.cs
+++ b/src/PixiParser.Benchmarks/Benchmarks/DeserializationBenchmarks.cs
@@ -20,7 +20,7 @@ namespace PixiEditor.Parser.Benchmarks
         [GlobalSetup]
         public void Setup()
         {
-            benchmarkDocument = PixiParser.Serialize(Helper.CreateDocument(Size, Layers));
+            benchmarkDocument = PixiParser.Serialize(Helper.CreateDocument(Size, Layers)).ToArray();
         }
 
         [Benchmark]

--- a/src/PixiParser.Benchmarks/Benchmarks/SerializationBenchmarks.cs
+++ b/src/PixiParser.Benchmarks/Benchmarks/SerializationBenchmarks.cs
@@ -1,0 +1,32 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace PixiEditor.Parser.Benchmarks
+{
+    [SimpleJob(RuntimeMoniker.NetCoreApp50, baseline: true)]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    [HtmlExporter]
+    [MarkdownExporterAttribute.GitHub]
+    public class SerializationBenchmarks
+    {
+        private SerializableDocument benchmarkDocument;
+
+        [Params(32, 64, 1920)]
+        public int Size;
+
+        [Params(1, 4)]
+        public int Layers;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            benchmarkDocument = Helper.CreateDocument(Size, Layers);
+        }
+
+        [Benchmark]
+        public void Serialize()
+        {
+            PixiParser.Serialize(benchmarkDocument);
+        }
+    }
+}

--- a/src/PixiParser.Benchmarks/Helper.cs
+++ b/src/PixiParser.Benchmarks/Helper.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace PixiEditor.Parser.Benchmarks
+{
+    public static class Helper
+    {
+        public static SerializableDocument CreateDocument(int Size, int Layers)
+        {
+            var benchmarkDocument = new SerializableDocument()
+            {
+                Width = Size,
+                Height = Size,
+                Swatches = new Tuple<byte, byte, byte, byte>[] { new Tuple<byte, byte, byte, byte>(0, 0, 0, 0) },
+                Layers = new SerializableLayer[Layers]
+            };
+
+            for (int i = 0; i < Layers; i++)
+            {
+                var layer = benchmarkDocument.Layers[i] = new SerializableLayer();
+                layer.BitmapBytes = new byte[Size * Size * 4];
+
+                new Random().NextBytes(layer.BitmapBytes);
+            }
+
+            return benchmarkDocument;
+        }
+    }
+}

--- a/src/PixiParser.Benchmarks/Helper.cs
+++ b/src/PixiParser.Benchmarks/Helper.cs
@@ -17,6 +17,10 @@ namespace PixiEditor.Parser.Benchmarks
             for (int i = 0; i < Layers; i++)
             {
                 var layer = benchmarkDocument.Layers[i] = new SerializableLayer();
+
+                layer.Width = Size;
+                layer.Height = Size;
+
                 layer.BitmapBytes = new byte[Size * Size * 4];
 
                 new Random().NextBytes(layer.BitmapBytes);

--- a/src/PixiParser.Benchmarks/PixiParser.Benchmarks.csproj
+++ b/src/PixiParser.Benchmarks/PixiParser.Benchmarks.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <RootNamespace>PixiEditor.Parser.Benchmarks</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PixiParser\PixiParser.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/PixiParser.Benchmarks/Program.cs
+++ b/src/PixiParser.Benchmarks/Program.cs
@@ -1,0 +1,13 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace PixiEditor.Parser.Benchmarks
+{
+    class Program
+    {
+        static void Main()
+        {
+            BenchmarkRunner.Run<SerializationBenchmarks>();
+            BenchmarkRunner.Run<DeserializationBenchmarks>();
+        }
+    }
+}

--- a/src/PixiParser.Tests/ParserTest.cs
+++ b/src/PixiParser.Tests/ParserTest.cs
@@ -1,9 +1,8 @@
 using System;
 using System.IO;
-using PixiEditor.Parser;
 using Xunit;
 
-namespace PixiEdtior.Tests
+namespace PixiEditor.Parser.Tests
 {
     public class ParserTest
     {

--- a/src/PixiParser.Tests/ParserTest.cs
+++ b/src/PixiParser.Tests/ParserTest.cs
@@ -38,7 +38,7 @@ namespace PixiEditor.Parser.Tests
         [Fact]
         public void DetectOldFile()
         {
-            Assert.Throws<OldFileFormatException>(delegate { PixiParser.Deserialize("./OldPixiFile.pixi"); });
+            Assert.Throws<OldFileFormatException>(() => PixiParser.Deserialize("./OldPixiFile.pixi"));
         }
 
         [Fact]

--- a/src/PixiParser.Tests/ParserTest.cs
+++ b/src/PixiParser.Tests/ParserTest.cs
@@ -24,7 +24,7 @@ namespace PixiEditor.Parser.Tests
                 OffsetX = 0, OffsetY = 0,
                 Opacity = 1 } };
 
-            byte[] serialized = PixiParser.Serialize(document);
+            Span<byte> serialized = PixiParser.Serialize(document);
 
             SerializableDocument deserializedDocument = PixiParser.Deserialize(serialized);
 

--- a/src/PixiParser.Tests/PixiParser.Tests.csproj
+++ b/src/PixiParser.Tests/PixiParser.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <RootNamespace>PixiEditor.Parser.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PixiParser.sln
+++ b/src/PixiParser.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PixiParser", "PixiParser\Pi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PixiParser.Tests", "PixiParser.Tests\PixiParser.Tests.csproj", "{FAFFE547-686D-4161-8519-9246CF6A4CC4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PixiParser.Benchmarks", "PixiParser.Benchmarks\PixiParser.Benchmarks.csproj", "{0680969C-3EDD-4D6C-AECA-6B5167F86470}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{FAFFE547-686D-4161-8519-9246CF6A4CC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FAFFE547-686D-4161-8519-9246CF6A4CC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FAFFE547-686D-4161-8519-9246CF6A4CC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0680969C-3EDD-4D6C-AECA-6B5167F86470}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0680969C-3EDD-4D6C-AECA-6B5167F86470}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0680969C-3EDD-4D6C-AECA-6B5167F86470}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0680969C-3EDD-4D6C-AECA-6B5167F86470}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/PixiParser/Helpers.cs
+++ b/src/PixiParser/Helpers.cs
@@ -7,6 +7,11 @@ namespace PixiEditor.Parser
     {
         public static Tuple<byte, byte, byte, byte>[] BytesToSwatches(byte[] bytes)
         {
+            if (bytes is null)
+            {
+                return Array.Empty<Tuple<byte, byte, byte, byte>>();
+            }
+
             List<Tuple<byte, byte, byte, byte>> swatches = new List<Tuple<byte, byte, byte, byte>>();
 
             // Convert the swatch byte array to a tuple array
@@ -25,6 +30,11 @@ namespace PixiEditor.Parser
 
         public static byte[] SwatchesToBytes(IEnumerable<Tuple<byte, byte, byte, byte>> swatches)
         {
+            if (swatches is null)
+            {
+                return Array.Empty<byte>();
+            }
+
             List<byte> tupleData = new List<byte>();
 
             foreach (var tuple in swatches)

--- a/src/PixiParser/Models/SerializableDocument.cs
+++ b/src/PixiParser/Models/SerializableDocument.cs
@@ -10,6 +10,9 @@ namespace PixiEditor.Parser
     [DataContract]
     public class SerializableDocument : IEnumerable<SerializableLayer>
     {
+        [DataMember(Order = 4)]
+        public Version FileVersion { get; set; } = new Version(1, 1);
+
         [DataMember(Order = 0)]
         public int Width { get; set; }
 

--- a/src/PixiParser/Models/SerializableDocument.cs
+++ b/src/PixiParser/Models/SerializableDocument.cs
@@ -20,10 +20,10 @@ namespace PixiEditor.Parser
         public int Height { get; set; }
 
         [DataMember(Order = 2)]
-        public byte[] SwatchesData { get; set; }
+        private byte[] SwatchesData { get; set; }
 
         [IgnoreDataMember]
-        public Tuple<byte, byte, byte, byte>[] Swatches { get; set; }
+        public Tuple<byte, byte, byte, byte>[] Swatches { get => Helpers.BytesToSwatches(SwatchesData); set => SwatchesData = Helpers.SwatchesToBytes(value); }
 
         [DataMember(Order = 3)]
         public SerializableLayer[] Layers { get; set; }

--- a/src/PixiParser/Models/SerializableDocument.cs
+++ b/src/PixiParser/Models/SerializableDocument.cs
@@ -2,26 +2,27 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace PixiEditor.Parser
 {
     [Serializable]
-    [MessagePackObject]
+    [DataContract]
     public class SerializableDocument : IEnumerable<SerializableLayer>
     {
-        [Key(0)]
+        [DataMember(Order = 0)]
         public int Width { get; set; }
 
-        [Key(1)]
+        [DataMember(Order = 1)]
         public int Height { get; set; }
 
-        [Key(2)]
+        [DataMember(Order = 2)]
         public byte[] SwatchesData { get; set; }
 
-        [IgnoreMember]
+        [IgnoreDataMember]
         public Tuple<byte, byte, byte, byte>[] Swatches { get; set; }
 
-        [Key(3)]
+        [DataMember(Order = 3)]
         public SerializableLayer[] Layers { get; set; }
 
         public IEnumerator<SerializableLayer> GetEnumerator()

--- a/src/PixiParser/Models/SerializableLayer.cs
+++ b/src/PixiParser/Models/SerializableLayer.cs
@@ -4,41 +4,42 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 
 namespace PixiEditor.Parser
 {
     [Serializable]
-    [MessagePackObject]
+    [DataContract]
     public class SerializableLayer
     {
-        [Key(4)]
+        [DataMember(Order = 4)]
         public string Name { get; set; }
 
-        [Key(0)]
+        [DataMember(Order = 0)]
         public int Width { get; set; }
 
-        [Key(1)]
+        [DataMember(Order = 1)]
         public int Height { get; set; }
 
-        [IgnoreMember]
+        [IgnoreDataMember]
         public int MaxWidth { get; set; }
 
-        [IgnoreMember]
+        [IgnoreDataMember]
         public int MaxHeight { get; set; }
 
-        [IgnoreMember]
+        [IgnoreDataMember]
         public byte[] BitmapBytes { get; set; }
 
-        [Key(5)]
+        [DataMember(Order = 5)]
         public bool IsVisible { get; set; }
 
-        [Key(2)]
+        [DataMember(Order = 2)]
         public int OffsetX { get; set; }
 
-        [Key(3)]
+        [DataMember(Order = 3)]
         public int OffsetY { get; set; }
 
-        [Key(6)]
+        [DataMember(Order = 6)]
         public float Opacity { get; set; }
 
         public Bitmap ToBitmap()

--- a/src/PixiParser/Parser/PixiParser.Deserialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Deserialize.cs
@@ -41,7 +41,7 @@ namespace PixiEditor.Parser
             }
             catch (ArgumentOutOfRangeException)
             {
-                throw new InvalidFileException("Invalid message pack lenght");
+                throw new InvalidFileException("Invalid message pack length");
             }
 
             SerializableDocument document;
@@ -119,19 +119,19 @@ namespace PixiEditor.Parser
 
         private static Span<byte> GetMessagePackBytes(Span<byte> span, ref int pos)
         {
-            // First four bytes are message pack lenght
-            int messagePackLenght = BitConverter.ToInt32(span.Slice(0, 4));
+            // First four bytes are message pack length
+            int messagePackLength = BitConverter.ToInt32(span.Slice(0, 4));
 
-            // The message pack lenght can't be 0
-            if (messagePackLenght == 0)
+            // The message pack length can't be 0
+            if (messagePackLength == 0)
             {
                 throw new InvalidFileException("This does not seem to be a .pixi file");
             }
 
             // At the fith byte the message pack begins
-            Span<byte> messagePackBytes = span.Slice(4, messagePackLenght);
+            Span<byte> messagePackBytes = span.Slice(4, messagePackLength);
 
-            pos += messagePackLenght + 4;
+            pos += messagePackLength + 4;
 
             return messagePackBytes;
         }
@@ -147,10 +147,10 @@ namespace PixiEditor.Parser
                 layer.MaxWidth = document.Width;
                 layer.MaxHeight = document.Height;
 
-                // Layer data lenght
-                int layerLenght = BitConverter.ToInt32(span.Slice(pos, 4));
+                // Layer data length
+                int layerLength = BitConverter.ToInt32(span.Slice(pos, 4));
 
-                if (layerLenght == 0)
+                if (layerLength == 0)
                 {
                     pos += 4;
                     layer.BitmapBytes = new byte[0];
@@ -161,14 +161,14 @@ namespace PixiEditor.Parser
 
                 try
                 {
-                    layer.BitmapBytes = ParsePNGToRawBytes(span.Slice(pos, layerLenght));
+                    layer.BitmapBytes = ParsePNGToRawBytes(span.Slice(pos, layerLength));
                 }
                 catch (InvalidFileException)
                 {
                     throw new InvalidFileException($"Parsing layer (Index: {i}) failed");
                 }
 
-                pos += layerLenght;
+                pos += layerLength;
                 i++;
             }
         }

--- a/src/PixiParser/Parser/PixiParser.Deserialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Deserialize.cs
@@ -22,6 +22,8 @@ namespace PixiEditor.Parser
             {
                 Span<byte> oldFileFormat = span.Slice(22, 8);
 
+                oldFileFormat.Reverse();
+
                 // The old format always begins with the same bytes
                 if (BitConverter.ToUInt64(oldFileFormat) == oldFormatIdentifier)
                 {

--- a/src/PixiParser/Parser/PixiParser.Deserialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Deserialize.cs
@@ -46,7 +46,9 @@ namespace PixiEditor.Parser
 
             try
             {
-                document = ParseMessagePack(messagePackBytes);
+                document = MessagePackSerializer.Deserialize<SerializableDocument>(
+                    messagePackBytes.ToArray(), 
+                    MessagePack.Resolvers.StandardResolverAllowPrivate.Options);
             }
             catch (MessagePackSerializationException)
             {
@@ -129,14 +131,6 @@ namespace PixiEditor.Parser
             pos += messagePackLenght + 4;
 
             return messagePackBytes;
-        }
-
-        private static SerializableDocument ParseMessagePack(Span<byte> bytes)
-        {
-            var document = MessagePackSerializer.Deserialize<SerializableDocument>(bytes.ToArray());
-            document.Swatches = Helpers.BytesToSwatches(document.SwatchesData);
-
-            return document;
         }
 
         private static void ParseLayerPNGs(ref SerializableDocument document, Span<byte> span, ref int pos)

--- a/src/PixiParser/Parser/PixiParser.Deserialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Deserialize.cs
@@ -1,11 +1,10 @@
-﻿using System;
+﻿using MessagePack;
+using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization.Formatters.Binary;
-using MessagePack;
 
 namespace PixiEditor.Parser
 {

--- a/src/PixiParser/Parser/PixiParser.Deserialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Deserialize.cs
@@ -18,12 +18,16 @@ namespace PixiEditor.Parser
         /// <returns>The deserialized Document.</returns>
         public static SerializableDocument Deserialize(Span<byte> span)
         {
-            Span<byte> oldFileFormat = span.Slice(22, 8);
-
-            // The old format always begins with the same bytes
-            if (BitConverter.ToUInt64(oldFileFormat) == oldFormatIdentifier)
+            if (span.Length > 40)
             {
-                throw new OldFileFormatException("This is a old .pixi file. Use DeserializeOld() to deserialize it");
+                Span<byte> oldFileFormat = span.Slice(22, 8);
+
+                // The old format always begins with the same bytes
+                if (BitConverter.ToUInt64(oldFileFormat) == oldFormatIdentifier)
+                {
+                    throw new OldFileFormatException("This is a old .pixi file. Use DeserializeOld() to deserialize it");
+                }
+
             }
 
             int pos = 0;

--- a/src/PixiParser/Parser/PixiParser.Deserialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Deserialize.cs
@@ -19,89 +19,38 @@ namespace PixiEditor.Parser
         /// <returns>The deserialized Document.</returns>
         public static SerializableDocument Deserialize(Span<byte> span)
         {
-            byte[] oldFileFormat = span.Slice(start: 22, 8).ToArray();
+            Span<byte> oldFileFormat = span.Slice(22, 8);
 
             // The old format always begins with the same bytes
-            if (BitConverter.ToUInt64(oldFileFormat.Reverse().ToArray()) == oldFormatIdentifier)
+            if (BitConverter.ToUInt64(oldFileFormat) == oldFormatIdentifier)
             {
                 throw new OldFileFormatException("This is a old .pixi file. Use DeserializeOld() to deserialize it");
             }
 
-            // The message pack lenght can't be 0
-            if (span[0] == 0)
-            {
-                throw new InvalidFileException("This does not seem to be a .pixi file");
-            }
-
-            int messagePackLenght;
-            byte[] messagePackBytes;
+            int pos = 0;
+            Span<byte> messagePackBytes;
 
             try
             {
-                // First four bytes are message pack lenght
-                byte[] messagePackLenghtBytes = span.Slice(0, 4).ToArray();
-                messagePackLenght = BitConverter.ToInt32(messagePackLenghtBytes, 0);
-
-                // At the fith byte the message pack begins
-                messagePackBytes = span.Slice(4, messagePackLenght).ToArray();
+                messagePackBytes = GetMessagePackBytes(span, ref pos);
             }
             catch (ArgumentOutOfRangeException)
             {
-                throw new InvalidFileException("This does not seem to be a .pixi file");
+                throw new InvalidFileException("Invalid message pack lenght");
             }
-
-            int pos = messagePackLenght + 4;
-            int i = 0;
 
             SerializableDocument document;
 
             try
             {
-                document = MessagePackSerializer.Deserialize<SerializableDocument>(messagePackBytes);
+                document = ParseMessagePack(messagePackBytes);
             }
             catch (MessagePackSerializationException)
             {
                 throw new InvalidFileException("Message Pack could not be deserialize");
             }
 
-            document.Swatches = Helpers.BytesToSwatches(document.SwatchesData);
-
-            // Deserialize layer data
-            while (pos < span.Length && document.Layers.Length > i)
-            {
-                SerializableLayer layer = document.Layers[i];
-                layer.MaxWidth = document.Width;
-                layer.MaxHeight = document.Height;
-
-                // Layer data lenght
-                int layerLenght = BitConverter.ToInt32(span.Slice(pos, 4));
-
-                if (layerLenght == 0)
-                {
-                    pos += 4;
-                    layer.BitmapBytes = new byte[0];
-                    continue;
-                }
-
-                pos += 4;
-
-                byte[] pngLayerData = span.Slice(pos, layerLenght).ToArray();
-                byte[] rawLayerData;
-
-                using (MemoryStream pngStream = new MemoryStream(pngLayerData))
-                {
-                    using Bitmap png = (Bitmap)Image.FromStream(pngStream);
-
-                    BitmapData data = png.LockBits(new Rectangle(0, 0, png.Width, png.Height), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
-                    rawLayerData = new byte[Math.Abs(data.Stride * data.Height)];
-                    Marshal.Copy(data.Scan0, rawLayerData, 0, rawLayerData.Length);
-                }
-
-                layer.BitmapBytes = rawLayerData;
-
-                pos += layerLenght;
-                i++;
-            }
+            ParseLayerPNGs(ref document, span, ref pos);
 
             return document;
         }
@@ -158,6 +107,84 @@ namespace PixiEditor.Parser
             formatter.Binder = new CurrentAssemblyDeserializationBinder();
 
             return (SerializableDocument)formatter.Deserialize(stream);
+        }
+
+        private static Span<byte> GetMessagePackBytes(Span<byte> span, ref int pos)
+        {
+            // First four bytes are message pack lenght
+            int messagePackLenght = BitConverter.ToInt32(span.Slice(0, 4));
+
+            // The message pack lenght can't be 0
+            if (messagePackLenght == 0)
+            {
+                throw new InvalidFileException("This does not seem to be a .pixi file");
+            }
+
+            // At the fith byte the message pack begins
+            Span<byte> messagePackBytes = span.Slice(4, messagePackLenght);
+
+            pos += messagePackLenght + 4;
+
+            return messagePackBytes;
+        }
+
+        private static SerializableDocument ParseMessagePack(Span<byte> bytes)
+        {
+            var document = MessagePackSerializer.Deserialize<SerializableDocument>(bytes.ToArray());
+            document.Swatches = Helpers.BytesToSwatches(document.SwatchesData);
+
+            return document;
+        }
+
+        private static void ParseLayerPNGs(ref SerializableDocument document, Span<byte> span, ref int pos)
+        {
+            int i = 0;
+
+            // Deserialize layer data
+            while (pos < span.Length && document.Layers.Length > i)
+            {
+                SerializableLayer layer = document.Layers[i];
+                layer.MaxWidth = document.Width;
+                layer.MaxHeight = document.Height;
+
+                // Layer data lenght
+                int layerLenght = BitConverter.ToInt32(span.Slice(pos, 4));
+
+                if (layerLenght == 0)
+                {
+                    pos += 4;
+                    layer.BitmapBytes = new byte[0];
+                    continue;
+                }
+
+                pos += 4;
+
+                try
+                {
+                    layer.BitmapBytes = ParsePNGToRawBytes(span.Slice(pos, layerLenght));
+                }
+                catch (InvalidFileException)
+                {
+                    throw new InvalidFileException($"Parsing layer (Index: {i}) failed");
+                }
+
+                pos += layerLenght;
+                i++;
+            }
+        }
+
+        private static byte[] ParsePNGToRawBytes(Span<byte> bytes)
+        {
+            byte[] rawLayerData;
+
+            using MemoryStream pngStream = new MemoryStream(bytes.ToArray());
+            using Bitmap png = (Bitmap)Image.FromStream(pngStream);
+
+            BitmapData data = png.LockBits(new Rectangle(0, 0, png.Width, png.Height), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+            rawLayerData = new byte[Math.Abs(data.Stride * data.Height)];
+            Marshal.Copy(data.Scan0, rawLayerData, 0, rawLayerData.Length);
+
+            return rawLayerData;
         }
     }
 }

--- a/src/PixiParser/Parser/PixiParser.Deserialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Deserialize.cs
@@ -74,8 +74,7 @@ namespace PixiEditor.Parser
                 layer.MaxHeight = document.Height;
 
                 // Layer data lenght
-                byte[] layerLenghtBytes = span.Slice(pos, 4).ToArray();
-                int layerLenght = BitConverter.ToInt32(layerLenghtBytes, 0);
+                int layerLenght = BitConverter.ToInt32(span.Slice(pos, 4));
 
                 if (layerLenght == 0)
                 {

--- a/src/PixiParser/Parser/PixiParser.Deserialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Deserialize.cs
@@ -48,7 +48,8 @@ namespace PixiEditor.Parser
             {
                 document = MessagePackSerializer.Deserialize<SerializableDocument>(
                     messagePackBytes.ToArray(), 
-                    MessagePack.Resolvers.StandardResolverAllowPrivate.Options);
+                    MessagePack.Resolvers.StandardResolverAllowPrivate.Options
+                        .WithSecurity(MessagePackSecurity.UntrustedData));
             }
             catch (MessagePackSerializationException)
             {

--- a/src/PixiParser/Parser/PixiParser.Serialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Serialize.cs
@@ -16,9 +16,7 @@ namespace PixiEditor.Parser
         {
             BinaryWriter writer = new BinaryWriter(stream);
 
-            document.SwatchesData = Helpers.SwatchesToBytes(document.Swatches);
-
-            byte[] messagePack = MessagePackSerializer.Serialize(document);
+            byte[] messagePack = MessagePackSerializer.Serialize(document, MessagePack.Resolvers.StandardResolverAllowPrivate.Options);
 
             writer.Write(messagePack.Length);
             writer.Write(messagePack);

--- a/src/PixiParser/Parser/PixiParser.Serialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Serialize.cs
@@ -39,7 +39,7 @@ namespace PixiEditor.Parser
 
             stream.Seek(0, SeekOrigin.Begin);
 
-            Span<byte> span = new Span<byte>();
+            Span<byte> span = new Span<byte>(new byte[stream.Length]);
 
             stream.Read(span);
 

--- a/src/PixiParser/Parser/PixiParser.Serialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Serialize.cs
@@ -16,20 +16,18 @@ namespace PixiEditor.Parser
         /// <param name="document">The document to serialize.</param>
         public static void Serialize(SerializableDocument document, Stream stream)
         {
-            BinaryWriter writeStream = new BinaryWriter(stream);
-
             document.SwatchesData = Helpers.SwatchesToBytes(document.Swatches);
 
             byte[] messagePack = MessagePackSerializer.Serialize(document);
 
-            writeStream.Write(messagePack.Length);
-            writeStream.Write(messagePack);
+            stream.Write(BitConverter.GetBytes(messagePack.Length));
+            stream.Write(messagePack);
 
             foreach (SerializableLayer layer in document)
             {
                 if (layer.Width * layer.Height == 0)
                 {
-                    writeStream.Write(0);
+                    stream.Write(BitConverter.GetBytes(0));
                     continue;
                 }
 
@@ -38,14 +36,16 @@ namespace PixiEditor.Parser
 
                 bitmap.Save(bitmapStream, ImageFormat.Png);
 
+                bitmapStream.Seek(0, SeekOrigin.Begin);
+
                 // Layer PNG Data Lenght
-                writeStream.Write(bitmapStream.Length);
-                bitmapStream.CopyTo(bitmapStream);
+                stream.Write(BitConverter.GetBytes((int)bitmapStream.Length));
+                bitmapStream.CopyTo(stream);
             }
 
             if (document.Layers.Length == 0)
             {
-                writeStream.Write(0);
+                stream.Write(BitConverter.GetBytes(0));
             }
         }
 

--- a/src/PixiParser/Parser/PixiParser.Serialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Serialize.cs
@@ -72,7 +72,7 @@ namespace PixiEditor.Parser
 
                 bitmapStream.Seek(0, SeekOrigin.Begin);
 
-                // Layer PNG Data Lenght
+                // Layer PNG Data Length
                 writer.Write((int)bitmapStream.Length);
                 bitmapStream.CopyTo(writer.BaseStream);
             }

--- a/src/PixiParser/Parser/PixiParser.Serialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Serialize.cs
@@ -25,30 +25,7 @@ namespace PixiEditor.Parser
             writer.Write(messagePack.Length);
             writer.Write(messagePack);
 
-            foreach (SerializableLayer layer in document)
-            {
-                if (layer.Width * layer.Height == 0)
-                {
-                    writer.Write(0);
-                    continue;
-                }
-
-                using Bitmap bitmap = layer.ToBitmap();
-                using MemoryStream bitmapStream = new MemoryStream();
-
-                bitmap.Save(bitmapStream, ImageFormat.Png);
-
-                bitmapStream.Seek(0, SeekOrigin.Begin);
-
-                // Layer PNG Data Lenght
-                writer.Write((int)bitmapStream.Length);
-                bitmapStream.CopyTo(stream);
-            }
-
-            if (document.Layers.Length == 0)
-            {
-                writer.Write(0);
-            }
+            WriteLayers(document, writer);
         }
 
         /// <summary>
@@ -80,6 +57,34 @@ namespace PixiEditor.Parser
             using FileStream stream = new FileStream(path, FileMode.Create, FileAccess.Write);
 
             Serialize(document, stream);
+        }
+
+        private static void WriteLayers(SerializableDocument document, BinaryWriter writer)
+        {
+            foreach (SerializableLayer layer in document)
+            {
+                if (layer.Width * layer.Height == 0)
+                {
+                    writer.Write(0);
+                    continue;
+                }
+
+                using Bitmap bitmap = layer.ToBitmap();
+                using MemoryStream bitmapStream = new MemoryStream();
+
+                bitmap.Save(bitmapStream, ImageFormat.Png);
+
+                bitmapStream.Seek(0, SeekOrigin.Begin);
+
+                // Layer PNG Data Lenght
+                writer.Write((int)bitmapStream.Length);
+                bitmapStream.CopyTo(writer.BaseStream);
+            }
+
+            if (document.Layers.Length == 0)
+            {
+                writer.Write(0);
+            }
         }
     }
 }

--- a/src/PixiParser/Parser/PixiParser.Serialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Serialize.cs
@@ -16,18 +16,20 @@ namespace PixiEditor.Parser
         /// <param name="document">The document to serialize.</param>
         public static void Serialize(SerializableDocument document, Stream stream)
         {
+            BinaryWriter writer = new BinaryWriter(stream);
+
             document.SwatchesData = Helpers.SwatchesToBytes(document.Swatches);
 
             byte[] messagePack = MessagePackSerializer.Serialize(document);
 
-            stream.Write(BitConverter.GetBytes(messagePack.Length));
-            stream.Write(messagePack);
+            writer.Write(messagePack.Length);
+            writer.Write(messagePack);
 
             foreach (SerializableLayer layer in document)
             {
                 if (layer.Width * layer.Height == 0)
                 {
-                    stream.Write(BitConverter.GetBytes(0));
+                    writer.Write(0);
                     continue;
                 }
 
@@ -39,13 +41,13 @@ namespace PixiEditor.Parser
                 bitmapStream.Seek(0, SeekOrigin.Begin);
 
                 // Layer PNG Data Lenght
-                stream.Write(BitConverter.GetBytes((int)bitmapStream.Length));
+                writer.Write((int)bitmapStream.Length);
                 bitmapStream.CopyTo(stream);
             }
 
             if (document.Layers.Length == 0)
             {
-                stream.Write(BitConverter.GetBytes(0));
+                writer.Write(0);
             }
         }
 

--- a/src/PixiParser/Parser/PixiParser.Serialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Serialize.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using MessagePack;
+using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
-using System.IO.Compression;
-using MessagePack;
 
 namespace PixiEditor.Parser
 {

--- a/src/PixiParser/Parser/PixiParser.Serialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Serialize.cs
@@ -33,7 +33,7 @@ namespace PixiEditor.Parser
         /// </summary>
         /// <param name="document">The document to serialize.</param>
         /// <returns>The serialized bytes.</returns>
-        public static byte[] Serialize(SerializableDocument document)
+        public static Span<byte> Serialize(SerializableDocument document)
         {
             MemoryStream stream = new MemoryStream();
 
@@ -41,11 +41,11 @@ namespace PixiEditor.Parser
 
             stream.Seek(0, SeekOrigin.Begin);
 
-            byte[] buffer = new byte[stream.Length];
+            Span<byte> span = new Span<byte>();
 
-            stream.Read(buffer, 0, buffer.Length);
+            stream.Read(span);
 
-            return buffer;
+            return span;
         }
 
         /// <summary>

--- a/src/PixiParser/PixiParser.csproj
+++ b/src/PixiParser/PixiParser.csproj
@@ -15,6 +15,8 @@
     <PackageIcon>PixiParserLogo.png</PackageIcon>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <Version>1.0.1.1</Version>
+    <AssemblyVersion>1.1.1.1</AssemblyVersion>
+    <FileVersion>1.1.1.1</FileVersion>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/src/PixiParser/PixiParser.csproj
+++ b/src/PixiParser/PixiParser.csproj
@@ -14,7 +14,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageIcon>PixiParserLogo.png</PackageIcon>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-    <Version>1.0.1.1</Version>
+    <Version>1.1.1.1</Version>
     <AssemblyVersion>1.1.1.1</AssemblyVersion>
     <FileVersion>1.1.1.1</FileVersion>
   </PropertyGroup>


### PR DESCRIPTION
Version 1.1 adds a benchmark project and more effective (de)serialization methods

List of major changes:
* Added benchmark project
* Only use `Span<byte>.ToArray()` when it's needed
* Use stream in serialization
* Added `FileVersion` property to the Document
* Code cleanup