### PR TITLE
Migrated to NET 6 (And made use of the file-scoped namespaces feature).

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,9 @@
+[*.cs]
+
+# IDE0022: Use block body for methods
+csharp_style_expression_bodied_methods =when_on_single_line:warning
+csharp_style_namespace_declarations=file_scoped:warning
+csharp_new_line_before_open_brace=all
+
+[*.{cs,vb}]
+end_of_line=crlf

--- a/src/PixiParser.Benchmarks/Benchmarks/Benchmarks.cs
+++ b/src/PixiParser.Benchmarks/Benchmarks/Benchmarks.cs
@@ -1,32 +1,30 @@
 ﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 
-namespace PixiEditor.Parser.Benchmarks
+namespace PixiEditor.Parser.Benchmarks;
+
+[SimpleJob(RuntimeMoniker.Net60, baseline: true)]
+[HtmlExporter]
+[MarkdownExporterAttribute.GitHub]
+public partial class Benchmarks
 {
-    [SimpleJob(RuntimeMoniker.NetCoreApp50, baseline: true)]
-    [SimpleJob(RuntimeMoniker.Net47)]
-    [HtmlExporter]
-    [MarkdownExporterAttribute.GitHub]
-    public partial class Benchmarks
+    [Params(64, 1920)]
+    public int Size;
+
+    [Params(1, 4)]
+    public int Layers;
+
+    [GlobalSetup]
+    public void Setup()
     {
-        [Params(64, 1920)]
-        public int Size;
+        benchmarkDocumentBytes = PixiParser.Serialize(Helper.CreateDocument(Size, Layers));
+        benchmarkDocument = Helper.CreateDocument(Size, Layers);
 
-        [Params(1, 4)]
-        public int Layers;
+        bitmaps = new SkiaSharp.SKBitmap[Layers];
 
-        [GlobalSetup]
-        public void Setup()
+        for (int i = 0; i < Layers; i++)
         {
-            benchmarkDocumentBytes = PixiParser.Serialize(Helper.CreateDocument(Size, Layers));
-            benchmarkDocument = Helper.CreateDocument(Size, Layers);
-
-            bitmaps = new SkiaSharp.SKBitmap[Layers];
-
-            for (int i = 0; i < Layers; i++)
-            {
-                bitmaps[i] = Helper.CreateSKBitmap(Size);
-            }
+            bitmaps[i] = Helper.CreateSKBitmap(Size);
         }
     }
 }

--- a/src/PixiParser.Benchmarks/Benchmarks/DeserializationBenchmarks.cs
+++ b/src/PixiParser.Benchmarks/Benchmarks/DeserializationBenchmarks.cs
@@ -1,15 +1,14 @@
 ﻿using BenchmarkDotNet.Attributes;
 
-namespace PixiEditor.Parser.Benchmarks
-{
-    public partial class Benchmarks
-    {
-        private byte[] benchmarkDocumentBytes;
+namespace PixiEditor.Parser.Benchmarks;
 
-        [Benchmark]
-        public SerializableDocument Deserialize()
-        {
-            return PixiParser.Deserialize(benchmarkDocumentBytes);
-        }
+public partial class Benchmarks
+{
+    private byte[] benchmarkDocumentBytes;
+
+    [Benchmark]
+    public SerializableDocument Deserialize()
+    {
+        return PixiParser.Deserialize(benchmarkDocumentBytes);
     }
 }

--- a/src/PixiParser.Benchmarks/Benchmarks/SerializationBenchmarks.cs
+++ b/src/PixiParser.Benchmarks/Benchmarks/SerializationBenchmarks.cs
@@ -1,32 +1,30 @@
 ﻿using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
 using SkiaSharp;
 
-namespace PixiEditor.Parser.Benchmarks
+namespace PixiEditor.Parser.Benchmarks;
+
+public partial class Benchmarks
 {
-    public partial class Benchmarks
+    private SerializableDocument benchmarkDocument;
+    private SKBitmap[] bitmaps;
+
+    [Benchmark]
+    public byte[] Serialize()
     {
-        private SerializableDocument benchmarkDocument;
-        private SKBitmap[] bitmaps;
+        return PixiParser.Serialize(benchmarkDocument);
+    }
 
-        [Benchmark]
-        public byte[] Serialize()
+    [Benchmark]
+    public byte[] SerializeAndCreate()
+    {
+        SerializableDocument document = Helper.CreateDocument(Size, Layers, false);
+
+        for (int i = 0; i < Layers; i++)
         {
-            return PixiParser.Serialize(benchmarkDocument);
+            SKData encoded = bitmaps[i].Encode(SKEncodedImageFormat.Png, 100);
+            document.Layers[i].PngBytes = encoded.AsSpan().ToArray();
         }
 
-        [Benchmark]
-        public byte[] SerializeAndCreate()
-        {
-            SerializableDocument document = Helper.CreateDocument(Size, Layers, false);
-
-            for (int i = 0; i < Layers; i++)
-            {
-                SKData encoded = bitmaps[i].Encode(SKEncodedImageFormat.Png, 100);
-                document.Layers[i].PngBytes = encoded.AsSpan().ToArray();
-            }
-
-            return PixiParser.Serialize(benchmarkDocument);
-        }
+        return PixiParser.Serialize(benchmarkDocument);
     }
 }

--- a/src/PixiParser.Benchmarks/Helper.cs
+++ b/src/PixiParser.Benchmarks/Helper.cs
@@ -1,53 +1,49 @@
-﻿using PixiEditor.Parser.Collections;
-using PixiEditor.Parser.Skia;
+﻿using PixiEditor.Parser.Skia;
 using SkiaSharp;
 using System;
-using System.Collections.Generic;
-using System.Drawing;
 
-namespace PixiEditor.Parser.Benchmarks
+namespace PixiEditor.Parser.Benchmarks;
+
+public static class Helper
 {
-    public static class Helper
+    public static SerializableDocument CreateDocument(int size, int layers, bool encodePng = true)
     {
-        public static SerializableDocument CreateDocument(int size, int layers, bool encodePng = true)
+        var benchmarkDocument = new SerializableDocument()
         {
-            var benchmarkDocument = new SerializableDocument()
+            Width = size,
+            Height = size
+        };
+
+        benchmarkDocument.Swatches.Add(255, 255, 255, 255);
+
+        for (int i = 0; i < layers; i++)
+        {
+            var layer = new SerializableLayer(size, size);
+
+            if (encodePng)
             {
-                Width = size,
-                Height = size
-            };
-
-            benchmarkDocument.Swatches.Add(255, 255, 255, 255);
-
-            for (int i = 0; i < layers; i++)
-            {
-                var layer = new SerializableLayer(size, size);
-
-                if (encodePng)
-                {
-                    layer.FromSKBitmap(CreateSKBitmap(size));
-                }
-
-                benchmarkDocument.Layers.Add(layer);
+                layer.FromSKBitmap(CreateSKBitmap(size));
             }
 
-            return benchmarkDocument;
+            benchmarkDocument.Layers.Add(layer);
         }
 
-        public static SKBitmap CreateSKBitmap(int size)
+        return benchmarkDocument;
+    }
+
+    public static SKBitmap CreateSKBitmap(int size)
+    {
+        Random random = new(2);
+        SKBitmap bitmap = new(size, size);
+
+        for (int y = 0; y < size; y++)
         {
-            Random random = new(2);
-            SKBitmap bitmap = new(size, size);
-
-            for (int y = 0; y < size; y++)
+            for (int x = 0; x < size; x++)
             {
-                for (int x = 0; x < size; x++)
-                {
-                    bitmap.SetPixel(x, y, new SKColor((uint)random.Next()));
-                }
+                bitmap.SetPixel(x, y, new SKColor((uint)random.Next()));
             }
-
-            return bitmap;
         }
+
+        return bitmap;
     }
 }

--- a/src/PixiParser.Benchmarks/PixiParser.Benchmarks.csproj
+++ b/src/PixiParser.Benchmarks/PixiParser.Benchmarks.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;net47</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>Latest</LangVersion>
     <RootNamespace>PixiEditor.Parser.Benchmarks</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="SkiaSharp" Version="2.80.3" />
   </ItemGroup>
 

--- a/src/PixiParser.Benchmarks/Program.cs
+++ b/src/PixiParser.Benchmarks/Program.cs
@@ -1,12 +1,11 @@
 ﻿using BenchmarkDotNet.Running;
 
-namespace PixiEditor.Parser.Benchmarks
+namespace PixiEditor.Parser.Benchmarks;
+
+internal class Program
 {
-    class Program
+    static void Main()
     {
-        static void Main()
-        {
-            BenchmarkRunner.Run<Benchmarks>();
-        }
+        BenchmarkRunner.Run<Benchmarks>();
     }
 }

--- a/src/PixiParser.Benchmarks/Program.cs
+++ b/src/PixiParser.Benchmarks/Program.cs
@@ -1,11 +1,4 @@
-﻿using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Running;
+using PixiEditor.Parser.Benchmarks;
 
-namespace PixiEditor.Parser.Benchmarks;
-
-internal class Program
-{
-    static void Main()
-    {
-        BenchmarkRunner.Run<Benchmarks>();
-    }
-}
+BenchmarkRunner.Run<Benchmarks>();

--- a/src/PixiParser.Skia/PixiParser.Skia.csproj
+++ b/src/PixiParser.Skia/PixiParser.Skia.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>PixiEditor.Parser.Skia</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/PixiParser.Skia/SkiaExtensions.cs
+++ b/src/PixiParser.Skia/SkiaExtensions.cs
@@ -7,19 +7,14 @@ public static class SkiaExtensions
     /// <summary>
     /// Creates a new <see cref="SKBitmap"/> from the png bytes of the layer
     /// </summary>
-    public static SKBitmap ToSKBitmap(this SerializableLayer layer)
-    {
-        return SKBitmap.Decode(layer.PngBytes, new SKImageInfo(layer.Width, layer.Height));
-    }
+    public static SKBitmap ToSKBitmap(this SerializableLayer layer) => 
+        SKBitmap.Decode(layer.PngBytes, new SKImageInfo(layer.Width, layer.Height));
 
     /// <summary>
     /// Creates a new <see cref="SKImage"/> from the png bytes of the layer
     /// </summary>
-    public static SKImage ToSKImage(this SerializableLayer layer)
-    {
-        return SKImage.FromEncodedData(layer.PngBytes);
-    }
-
+    public static SKImage ToSKImage(this SerializableLayer layer) => SKImage.FromEncodedData(layer.PngBytes);
+    
     /// <summary>
     /// Encodes the <paramref name="bitmap"/> into the png bytes of the layer
     /// </summary>

--- a/src/PixiParser.Skia/SkiaExtensions.cs
+++ b/src/PixiParser.Skia/SkiaExtensions.cs
@@ -1,58 +1,90 @@
-using PixiEditor.Parser.Collections;
 using SkiaSharp;
-using System.Collections.Generic;
-using System.Drawing;
 
-namespace PixiEditor.Parser.Skia
+namespace PixiEditor.Parser.Skia;
+
+public static class SkiaExtensions
 {
-    public static class SkiaExtensions
+    /// <summary>
+    /// Creates a new <see cref="SKBitmap"/> from the png bytes of the layer
+    /// </summary>
+    public static SKBitmap ToSKBitmap(this SerializableLayer layer)
     {
-        /// <summary>
-        /// Creates a new <see cref="SKBitmap"/> from the png bytes of the layer
-        /// </summary>
-        public static SKBitmap ToSKBitmap(this SerializableLayer layer)
+        return SKBitmap.Decode(layer.PngBytes, new SKImageInfo(layer.Width, layer.Height));
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="SKImage"/> from the png bytes of the layer
+    /// </summary>
+    public static SKImage ToSKImage(this SerializableLayer layer)
+    {
+        return SKImage.FromEncodedData(layer.PngBytes);
+    }
+
+    /// <summary>
+    /// Encodes the <paramref name="bitmap"/> into the png bytes of the layer
+    /// </summary>
+    /// <param name="bitmap">The bitmap that should be encoded</param>
+    /// <returns><paramref name="layer"/></returns>
+    public static SerializableLayer FromSKBitmap(this SerializableLayer layer, SKBitmap bitmap)
+    {
+        using SKData data = bitmap.Encode(SKEncodedImageFormat.Png, 100);
+
+        layer.PngBytes = data.AsSpan().ToArray();
+        layer.Width = bitmap.Width;
+        layer.Height = bitmap.Height;
+
+        return layer;
+    }
+
+    /// <summary>
+    /// Encodes the <paramref name="image"/> into the png bytes of the layer
+    /// </summary>
+    /// <param name="bitmap">The bitmap that should be encoded</param>
+    /// <returns><paramref name="image"/></returns>
+    public static SerializableLayer FromSKImage(this SerializableLayer layer, SKImage image)
+    {
+        using SKData data = image.Encode();
+
+        layer.PngBytes = data.AsSpan().ToArray();
+        layer.Width = image.Width;
+        layer.Height = image.Height;
+
+        return layer;
+    }
+
+    public static SKBitmap ToSKBitmap(this SerializableDocument document)
+    {
+        SKImageInfo info = new(document.Width, document.Height, SKColorType.RgbaF32, SKAlphaType.Unpremul, SKColorSpace.CreateSrgb());
+        using SKSurface surface = SKSurface.Create(info);
+        SKCanvas canvas = surface.Canvas;
+        using SKPaint paint = new();
+
+        foreach (SerializableLayer layer in document)
         {
-            return SKBitmap.Decode(layer.PngBytes, new SKImageInfo(layer.Width, layer.Height));
+            bool visible = document.Layers.GetFinalLayerVisibilty(layer);
+
+            if (!visible)
+            {
+                continue;
+            }
+
+            double opacity = document.Layers.GetFinalLayerOpacity(layer);
+
+            if (opacity == 0)
+            {
+                continue;
+            }
+
+            using SKColorFilter filter = SKColorFilter.CreateBlendMode(SKColors.White.WithAlpha((byte)(opacity * 255)), SKBlendMode.DstIn);
+            paint.ColorFilter = filter;
+
+            canvas.DrawImage(layer.ToSKImage(), layer.OffsetX, layer.OffsetY, paint);
         }
 
-        /// <summary>
-        /// Creates a new <see cref="SKImage"/> from the png bytes of the layer
-        /// </summary>
-        public static SKImage ToSKImage(this SerializableLayer layer)
-        {
-            return SKImage.FromEncodedData(layer.PngBytes);
-        }
+        SKBitmap bitmap = new(info);
 
-        /// <summary>
-        /// Encodes the <paramref name="bitmap"/> into the png bytes of the layer
-        /// </summary>
-        /// <param name="bitmap">The bitmap that should be encoded</param>
-        /// <returns><paramref name="layer"/></returns>
-        public static SerializableLayer FromSKBitmap(this SerializableLayer layer, SKBitmap bitmap)
-        {
-            using SKData data = bitmap.Encode(SKEncodedImageFormat.Png, 100);
+        surface.ReadPixels(info, bitmap.GetPixels(), info.RowBytes, 0, 0);
 
-            layer.PngBytes = data.AsSpan().ToArray();
-            layer.Width = bitmap.Width;
-            layer.Height = bitmap.Height;
-
-            return layer;
-        }
-
-        /// <summary>
-        /// Encodes the <paramref name="image"/> into the png bytes of the layer
-        /// </summary>
-        /// <param name="bitmap">The bitmap that should be encoded</param>
-        /// <returns><paramref name="image"/></returns>
-        public static SerializableLayer FromSKImage(this SerializableLayer layer, SKImage image)
-        {
-            using SKData data = image.Encode();
-
-            layer.PngBytes = data.AsSpan().ToArray();
-            layer.Width = image.Width;
-            layer.Height = image.Height;
-
-            return layer;
-        }
+        return bitmap;
     }
 }

--- a/src/PixiParser.Skia/SkiaExtensions.cs
+++ b/src/PixiParser.Skia/SkiaExtensions.cs
@@ -52,7 +52,12 @@ public static class SkiaExtensions
         return layer;
     }
 
-    public static SKBitmap ToSKBitmap(this SerializableDocument document)
+    /// <summary>
+    /// Draws all layers on top of a <see cref="SKBitmap"/>
+    /// </summary>
+    /// <param name="document"></param>
+    /// <returns>The <see cref="SKBitmap"/> instance</returns>
+    public static SKBitmap LayersToSKBitmap(this SerializableDocument document)
     {
         SKImageInfo info = new(document.Width, document.Height, SKColorType.RgbaF32, SKAlphaType.Unpremul, SKColorSpace.CreateSrgb());
         using SKSurface surface = SKSurface.Create(info);

--- a/src/PixiParser.Skia/SwatchExtensions.cs
+++ b/src/PixiParser.Skia/SwatchExtensions.cs
@@ -3,43 +3,42 @@ using SkiaSharp;
 using System.Collections.Generic;
 using System.Drawing;
 
-namespace PixiEditor.Parser.Skia
+namespace PixiEditor.Parser.Skia;
+
+public static class SwatchExtensions
 {
-    public static class SwatchExtensions
+    /// <summary>
+    /// Iterates the <see cref="Color"/>'s in the <paramref name="collection"/> collection and converts them into <see cref="SKColor"/>'s
+    /// </summary>
+    public static IEnumerable<SKColor> ToSKColors(this SwatchCollection collection)
     {
-        /// <summary>
-        /// Iterates the <see cref="Color"/>'s in the <paramref name="collection"/> collection and converts them into <see cref="SKColor"/>'s
-        /// </summary>
-        public static IEnumerable<SKColor> ToSKColors(this SwatchCollection collection)
+        foreach (Color color in collection)
         {
-            foreach (Color color in collection)
-            {
-                yield return new SKColor(color.R,
-                                         color.G,
-                                         color.B,
-                                         color.A);
-            }
+            yield return new SKColor(color.R,
+                                     color.G,
+                                     color.B,
+                                     color.A);
         }
+    }
 
-        /// <summary>
-        /// Adds the elements of the specified collection to the end of the <paramref name="collection"/>
-        /// </summary>
-        /// <return>The created <see cref="Color"/> instances</return>
-        public static IEnumerable<Color> AddRange(this SwatchCollection collection, IEnumerable<SKColor> colors)
+    /// <summary>
+    /// Adds the elements of the specified collection to the end of the <paramref name="collection"/>
+    /// </summary>
+    /// <return>The created <see cref="Color"/> instances</return>
+    public static IEnumerable<Color> AddRange(this SwatchCollection collection, IEnumerable<SKColor> colors)
+    {
+        foreach (SKColor color in colors)
         {
-            foreach (SKColor color in colors)
-            {
-                yield return collection.Add(color);
-            }
+            yield return collection.Add(color);
         }
+    }
 
-        /// <summary>
-        /// Add's the <paramref name="color"/> to the <paramref name="collection"/> and returns the new <see cref="Color"/> instance
-        /// </summary>
-        /// <returns>The created <see cref="Color"/> instance</returns>
-        public static Color Add(this SwatchCollection collection, SKColor color)
-        {
-            return collection.Add(color.Alpha, color.Red, color.Green, color.Blue);
-        }
+    /// <summary>
+    /// Add's the <paramref name="color"/> to the <paramref name="collection"/> and returns the new <see cref="Color"/> instance
+    /// </summary>
+    /// <returns>The created <see cref="Color"/> instance</returns>
+    public static Color Add(this SwatchCollection collection, SKColor color)
+    {
+        return collection.Add(color.Alpha, color.Red, color.Green, color.Blue);
     }
 }

--- a/src/PixiParser.Tests/ParserTests.cs
+++ b/src/PixiParser.Tests/ParserTests.cs
@@ -1,141 +1,138 @@
-using System;
-using System.Collections.Generic;
 using Xunit;
 
-namespace PixiEditor.Parser.Tests
+namespace PixiEditor.Parser.Tests;
+
+public class ParserTests
 {
-    public class ParserTests
+    [Fact]
+    public void SerializingAndDeserialzingWorks()
     {
-        [Fact]
-        public void SerializingAndDeserialzingWorks()
+        SerializableDocument document = new()
         {
-            SerializableDocument document = new()
-            {
-                Height = 1,
-                Width = 1
-            };
+            Height = 1,
+            Width = 1
+        };
 
-            document.Swatches.Add(255, 255, 255);
+        document.Swatches.Add(255, 255, 255);
 
-            SerializableLayer layer = document.Layers.Add("Base Layer", 1, 1, false, 0.5f, 1, 1);
-            layer.PngBytes = new byte[] { 0xFF, 0xFF, 0xFF, 0xFF };
+        SerializableLayer layer = document.Layers.Add("Base Layer", 1, 1, false, 0.5f, 1, 1);
+        layer.PngBytes = new byte[] { 0xFF, 0xFF, 0xFF, 0xFF };
 
-            document.Groups.Add(new SerializableGroup("Base Group"));
+        document.Groups.Add(new SerializableGroup("Base Group"));
 
-            byte[] serialized = PixiParser.Serialize(document);
+        byte[] serialized = PixiParser.Serialize(document);
 
-            SerializableDocument deserializedDocument = PixiParser.Deserialize(serialized);
+        SerializableDocument deserializedDocument = PixiParser.Deserialize(serialized);
 
-            AssertEqual(document, deserializedDocument);
+        AssertEqual(document, deserializedDocument);
+    }
+
+    [Fact]
+    public void SerializeAndDeserializeEmptyLayer()
+    {
+        SerializableDocument document = new()
+        {
+            Width = 1,
+            Height = 1
+        };
+
+        document.Layers.Add("Base Layer");
+
+        var serialized = PixiParser.Serialize(document);
+
+        SerializableDocument deserialized = PixiParser.Deserialize(serialized);
+
+        AssertEqual(document, deserialized);
+    }
+
+    [Fact]
+    public void DetectOldFile()
+    {
+        Assert.Throws<OldFileFormatException>(() => PixiParser.Deserialize("./Files/OldPixiFile.pixi"));
+    }
+
+    [Fact]
+    public void DetectCorruptedFile()
+    {
+        Assert.Throws<InvalidFileException>(() => PixiParser.Deserialize("./Files/CorruptedPixiFile.pixi"));
+    }
+
+    [Fact]
+    public void CanOpenExistingFile()
+    {
+        PixiParser.Deserialize("./Files/16x16,PPD-3.pixi");
+    }
+
+    [Fact]
+    public void IsBackwardsCompatible()
+    {
+        PixiParser.Deserialize("./Files/16x16,PE-0.6.pixi");
+    }
+
+    [Fact]
+    public void LayerStructureWorks()
+    {
+        SerializableDocument document = new();
+
+        SerializableLayer layer1 = document.Layers.Add("Test Layer 1");
+        SerializableLayer layer2 = document.Layers.Add("Test Layer 2");
+        SerializableLayer layer3 = document.Layers.Add("Test Layer 3");
+        SerializableLayer layer4 = document.Layers.Add("Test Layer 4");
+
+        SerializableGroup group1 = new("Group 1");
+        SerializableGroup group2 = new("Group 1|1");
+        group1.Subgroups.Add(group2);
+        SerializableGroup group3 = new("Group 2");
+
+        document.Groups.Add(group1);
+        document.Groups.Add(group2);
+        document.Groups.Add(group3);
+
+        document.Layers.AddToGroup(group1, layer1);
+        document.Layers.AddToGroup(group2, layer2);
+        document.Layers.AddToGroup(group1, layer3);
+
+        document.Layers.AddToGroup(group3, layer4);
+
+        Assert.Equal(0, document.Groups[0].StartLayer);
+        Assert.Equal(2, document.Groups[0].EndLayer);
+
+        Assert.Equal(1, document.Groups[1].StartLayer);
+        Assert.Equal(1, document.Groups[1].EndLayer);
+
+        Assert.Equal(3, document.Groups[2].StartLayer);
+        Assert.Equal(3, document.Groups[2].EndLayer);
+
+        Assert.True(document.Layers.ContainedIn(group1, layer1));
+        Assert.True(document.Layers.ContainedIn(group1, layer2));
+        Assert.True(document.Layers.ContainedIn(group1, layer3));
+        Assert.True(document.Layers.ContainedIn(group2, layer2));
+        Assert.False(document.Layers.ContainedIn(group1, layer4));
+        Assert.True(document.Layers.ContainedIn(group3, layer4));
+    }
+
+    private static void AssertEqual(SerializableDocument document, SerializableDocument otherDocument)
+    {
+        Assert.Equal(document.FileVersion, otherDocument.FileVersion);
+        Assert.Equal(document.Height, otherDocument.Height);
+        Assert.Equal(document.Width, otherDocument.Width);
+        Assert.Equal(document.Swatches.Count, otherDocument.Swatches.Count);
+        Assert.Equal(document.Layers.Count, document.Layers.Count);
+        Assert.Equal(document.Groups.Count, document.Groups.Count);
+
+        for (int i = 0; i < document.Swatches.Count; i++)
+        {
+            Assert.Equal(document.Swatches[i], otherDocument.Swatches[i]);
         }
 
-        [Fact]
-        public void SerializeAndDeserializeEmptyLayer()
+        for (int i = 0; i < document.Layers.Count; i++)
         {
-            SerializableDocument document = new()
-            {
-                Width = 1,
-                Height = 1
-            };
-
-            document.Layers.Add("Base Layer");
-
-            var serialized = PixiParser.Serialize(document);
-
-            SerializableDocument deserialized = PixiParser.Deserialize(serialized);
-
-            AssertEqual(document, deserialized);
+            Assert.Equal(document.Layers[i], otherDocument.Layers[i]);
         }
 
-        [Fact]
-        public void DetectOldFile()
+        for (int i = 0; i < document.Groups.Count; i++)
         {
-            Assert.Throws<OldFileFormatException>(() => PixiParser.Deserialize("./Files/OldPixiFile.pixi"));
-        }
-
-        [Fact]
-        public void DetectCorruptedFile()
-        {
-            Assert.Throws<InvalidFileException>(() => PixiParser.Deserialize("./Files/CorruptedPixiFile.pixi"));
-        }
-
-        [Fact]
-        public void CanOpenExistingFile()
-        {
-            PixiParser.Deserialize("./Files/16x16,PPD-3.pixi");
-        }
-
-        [Fact]
-        public void IsBackwardsCompatible()
-        {
-            PixiParser.Deserialize("./Files/16x16,PE-0.6.pixi");
-        }
-
-        [Fact]
-        public void LayerStructureWorks()
-        {
-            SerializableDocument document = new();
-
-            SerializableLayer layer1 = document.Layers.Add("Test Layer 1");
-            SerializableLayer layer2 = document.Layers.Add("Test Layer 2");
-            SerializableLayer layer3 = document.Layers.Add("Test Layer 3");
-            SerializableLayer layer4 = document.Layers.Add("Test Layer 4");
-
-            SerializableGroup group1 = new("Group 1");
-            SerializableGroup group2 = new("Group 1|1");
-            group1.Subgroups.Add(group2);
-            SerializableGroup group3 = new("Group 2");
-
-            document.Groups.Add(group1);
-            document.Groups.Add(group2);
-            document.Groups.Add(group3);
-
-            document.Layers.AddToGroup(group1, layer1);
-            document.Layers.AddToGroup(group2, layer2);
-            document.Layers.AddToGroup(group1, layer3);
-
-            document.Layers.AddToGroup(group3, layer4);
-
-            Assert.Equal(0, document.Groups[0].StartLayer);
-            Assert.Equal(2, document.Groups[0].EndLayer);
-
-            Assert.Equal(1, document.Groups[1].StartLayer);
-            Assert.Equal(1, document.Groups[1].EndLayer);
-
-            Assert.Equal(3, document.Groups[2].StartLayer);
-            Assert.Equal(3, document.Groups[2].EndLayer);
-
-            Assert.True(document.Layers.ContainedIn(group1, layer1));
-            Assert.True(document.Layers.ContainedIn(group1, layer2));
-            Assert.True(document.Layers.ContainedIn(group1, layer3));
-            Assert.True(document.Layers.ContainedIn(group2, layer2));
-            Assert.False(document.Layers.ContainedIn(group1, layer4));
-            Assert.True(document.Layers.ContainedIn(group3, layer4));
-        }
-
-        private static void AssertEqual(SerializableDocument document, SerializableDocument otherDocument)
-        {
-            Assert.Equal(document.FileVersion, otherDocument.FileVersion);
-            Assert.Equal(document.Height, otherDocument.Height);
-            Assert.Equal(document.Width, otherDocument.Width);
-            Assert.Equal(document.Swatches.Count, otherDocument.Swatches.Count);
-            Assert.Equal(document.Layers.Count, document.Layers.Count);
-            Assert.Equal(document.Groups.Count, document.Groups.Count);
-
-            for (int i = 0; i < document.Swatches.Count; i++)
-            {
-                Assert.Equal(document.Swatches[i], otherDocument.Swatches[i]);
-            }
-
-            for (int i = 0; i < document.Layers.Count; i++)
-            {
-                Assert.Equal(document.Layers[i], otherDocument.Layers[i]);
-            }
-
-            for (int i = 0; i < document.Groups.Count; i++)
-            {
-                Assert.Equal(document.Groups[i], otherDocument.Groups[i]);
-            }
+            Assert.Equal(document.Groups[i], otherDocument.Groups[i]);
         }
     }
 }

--- a/src/PixiParser.Tests/PixiParser.Tests.csproj
+++ b/src/PixiParser.Tests/PixiParser.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/PixiParser.Tests/SkiaTests.cs
+++ b/src/PixiParser.Tests/SkiaTests.cs
@@ -1,49 +1,45 @@
 ﻿using PixiEditor.Parser.Skia;
 using SkiaSharp;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
-namespace PixiEditor.Parser.Tests
+namespace PixiEditor.Parser.Tests;
+
+public class SkiaTests
 {
-    public class SkiaTests
+    [Fact]
+    public void CanCreateSKBitmapFromLayer()
     {
-        [Fact]
-        public void CanCreateSKBitmapFromLayer()
-        {
-            SerializableDocument document = PixiParser.Deserialize("./Files/16x16,PPD-3.pixi");
+        SerializableDocument document = PixiParser.Deserialize("./Files/16x16,PPD-3.pixi");
 
-            SerializableLayer layer = document.Layers[0];
-            using SKBitmap bitmap = layer.ToSKBitmap();
+        SerializableLayer layer = document.Layers[0];
+        using SKBitmap bitmap = layer.ToSKBitmap();
 
-            Assert.Equal(layer.Width, bitmap.Width);
-        }
+        Assert.Equal(layer.Width, bitmap.Width);
+    }
 
-        [Fact]
-        public void CanCreateSKImageFromLayer()
-        {
-            SerializableDocument document = PixiParser.Deserialize("./Files/16x16,PPD-3.pixi");
+    [Fact]
+    public void CanCreateSKImageFromLayer()
+    {
+        SerializableDocument document = PixiParser.Deserialize("./Files/16x16,PPD-3.pixi");
 
-            SerializableLayer layer = document.Layers[0];
-            using SKImage image = layer.ToSKImage();
+        SerializableLayer layer = document.Layers[0];
+        using SKImage image = layer.ToSKImage();
 
-            Assert.Equal(layer.Width, image.Width);
-        }
+        Assert.Equal(layer.Width, image.Width);
+    }
 
-        [Fact]
-        public void CanEncodeBitmapBytesFromSKBitmap()
-        {
-            const int width = 20;
-            const int height = 20;
+    [Fact]
+    public void CanEncodeBitmapBytesFromSKBitmap()
+    {
+        const int width = 20;
+        const int height = 20;
 
-            SerializableDocument document = new(width, height);
-            using SKBitmap bitmap = new(width, height);
+        SerializableDocument document = new(width, height);
+        using SKBitmap bitmap = new(width, height);
 
-            document.Layers.Add(new SerializableLayer(width, height));
-            document.Layers[0].FromSKBitmap(bitmap);
+        document.Layers.Add(new SerializableLayer(width, height));
+        document.Layers[0].FromSKBitmap(bitmap);
 
-            Assert.NotEmpty(document.Layers[0].PngBytes);
-        }
+        Assert.NotEmpty(document.Layers[0].PngBytes);
     }
 }

--- a/src/PixiParser/Collections/LayerCollection.cs
+++ b/src/PixiParser/Collections/LayerCollection.cs
@@ -4,277 +4,276 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 
-namespace PixiEditor.Parser.Collections
+namespace PixiEditor.Parser.Collections;
+
+[DebuggerDisplay("Count = {Count}")]
+public class LayerCollection : IList<SerializableLayer>
 {
-    [DebuggerDisplay("Count = {Count}")]
-    public class LayerCollection : IList<SerializableLayer>
+    private readonly SerializableDocument _document;
+    private readonly List<SerializableLayer> _layers;
+
+    public SerializableLayer this[int index] { get => _layers[index]; set => _layers[index] = value; }
+
+    public int Count => _layers.Count;
+
+    public bool IsReadOnly => false;
+
+    internal LayerCollection(SerializableDocument document)
     {
-        private readonly SerializableDocument _document;
-        private readonly List<SerializableLayer> _layers;
+        _document = document;
+        _layers = new List<SerializableLayer>();
+    }
 
-        public SerializableLayer this[int index] { get => _layers[index]; set => _layers[index] = value; }
+    internal LayerCollection(SerializableDocument document, IEnumerable<SerializableLayer> layers)
+    {
+        _document = document;
+        _layers = new List<SerializableLayer>(layers);
+    }
 
-        public int Count => _layers.Count;
+    internal LayerCollection(SerializableDocument document, List<SerializableLayer> layers)
+    {
+        _document = document;
+        _layers = layers;
+    }
 
-        public bool IsReadOnly => false;
+    public void Add(SerializableLayer item)
+    {
+        _layers.Add(item);
+    }
 
-        internal LayerCollection(SerializableDocument document)
+    public void Clear()
+    {
+        _layers.Clear();
+        _document.ClearGroupLayerIndexes();
+    }
+
+    public bool Contains(SerializableLayer item) => _layers.Contains(item);
+
+    public void CopyTo(SerializableLayer[] array, int arrayIndex)
+    {
+        for (int i = 0; i < _layers.Count; i++)
         {
-            _document = document;
-            _layers = new List<SerializableLayer>();
+            array[arrayIndex + i] = _layers[i];
+        }
+    }
+
+    public IEnumerator<SerializableLayer> GetEnumerator() => _layers.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _layers.GetEnumerator();
+
+    public int IndexOf(SerializableLayer item) => _layers.IndexOf(item);
+
+    public void Insert(int index, SerializableLayer item)
+    {
+        _document.IncreaseGroupLayerIndexes(index);
+        _layers.Insert(index, item);
+    }
+
+    public bool Remove(SerializableLayer item)
+    {
+        int index = _layers.IndexOf(item);
+        if (index == -1) return false;
+
+        RemoveAt(index);
+        return true;
+    }
+
+    public void RemoveAt(int index)
+    {
+        if (index < 0 || index >= _layers.Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
         }
 
-        internal LayerCollection(SerializableDocument document, IEnumerable<SerializableLayer> layers)
+        _document.DecreaseGroupLayerIndexes(index);
+        _layers.RemoveAt(index);
+    }
+
+    public SerializableLayer Add(string name) => Add(name, 0, 0);
+
+    public SerializableLayer Add(string name, int width, int height, bool isVisible = true, float opacity = 1, int offsetX = 0, int offsetY = 0)
+    {
+        SerializableLayer layer = new SerializableLayer(width, height, offsetX, offsetY) { IsVisible = isVisible, Opacity = opacity, Name = name };
+        Add(layer);
+        return layer;
+    }
+
+    /// <summary>
+    /// Moves the <paramref name="layer"/> to the specified <paramref name="index"/>
+    /// </summary>
+    /// <param name="layer">The layer to move</param>
+    /// <param name="index">The index where the <paramref name="layer"/> should be moved to</param>
+    /// <returns>If the move operation was successfull (Returns false if the <paramref name="layer"/> couldn't be found)</returns>
+    public bool MoveTo(SerializableLayer layer, int index)
+    {
+        int layerIndex = IndexOf(layer);
+
+        if (layerIndex == -1 || index == -1)
         {
-            _document = document;
-            _layers = new List<SerializableLayer>(layers);
+            return false;
         }
 
-        internal LayerCollection(SerializableDocument document, List<SerializableLayer> layers)
+        RemoveAt(layerIndex);
+        Insert(index, layer);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Moves the <paramref name="toMove"/> layer below the <paramref name="target"/> layer
+    /// </summary>
+    /// <param name="toMove">The layer to move</param>
+    /// <param name="target">The layer which should appear above the <paramref name="toMove"/> layer</param>
+    /// <returns>If the move operation was successfull (Returns false if <paramref name="toMove"/> or <paramref name="target"/> couldn't be found)</returns>
+    public bool MoveBelow(SerializableLayer toMove, SerializableLayer target)
+    {
+        return MoveTo(toMove, IndexOf(target));
+    }
+
+    /// <summary>
+    /// Moves the <paramref name="toMove"/> layer above the <paramref name="target"/> layer
+    /// </summary>
+    /// <param name="toMove">The layer to move</param>
+    /// <param name="target">The layer which should appear below the <paramref name="toMove"/> layer</param>
+    /// <returns>If the move operation was successfull (Returns false if <paramref name="toMove"/> or <paramref name="target"/> couldn't be found)</returns>
+    public bool MoveAbove(SerializableLayer toMove, SerializableLayer target)
+    {
+        return MoveTo(toMove, IndexOf(target) + 1);
+    }
+
+    /// <summary>
+    /// Get's the opacity of <paramref name="layer"/> respecting the opacity of the parent groups
+    /// </summary>
+    public double GetFinalLayerOpacity(SerializableLayer layer)
+    {
+        if (layer.Opacity == 0)
         {
-            _document = document;
-            _layers = layers;
+            return 0f;
         }
 
-        public void Add(SerializableLayer item)
+        double finalOpacity = layer.Opacity;
+        var groups = GetGroups(layer);
+
+        if (groups == null)
         {
-            _layers.Add(item);
+            throw new InvalidOperationException("The layer was not found in the layer collection.");
         }
 
-        public void Clear()
+        foreach (var group in groups)
         {
-            _layers.Clear();
-            _document.ClearGroupLayerIndexes();
+            finalOpacity *= group.Opacity;
         }
 
-        public bool Contains(SerializableLayer item) => _layers.Contains(item);
+        return finalOpacity;
+    }
 
-        public void CopyTo(SerializableLayer[] array, int arrayIndex)
+    public bool GetFinalLayerVisibilty(SerializableLayer layer)
+    {
+        if (!layer.IsVisible)
         {
-            for (int i = 0; i < _layers.Count; i++)
-            {
-                array[arrayIndex + i] = _layers[i];
-            }
+            return false;
         }
 
-        public IEnumerator<SerializableLayer> GetEnumerator() => _layers.GetEnumerator();
+        var groups = GetGroups(layer);
 
-        IEnumerator IEnumerable.GetEnumerator() => _layers.GetEnumerator();
-
-        public int IndexOf(SerializableLayer item) => _layers.IndexOf(item);
-
-        public void Insert(int index, SerializableLayer item)
+        if (groups == null)
         {
-            _document.IncreaseGroupLayerIndexes(index);
-            _layers.Insert(index, item);
+            throw new InvalidOperationException("The layer was not found in the layer collection.");
         }
 
-        public bool Remove(SerializableLayer item)
+        foreach (var group in groups)
         {
-            int index = _layers.IndexOf(item);
-            if (index == -1) return false;
-
-            RemoveAt(index);
-            return true;
-        }
-
-        public void RemoveAt(int index)
-        {
-            if (index < 0 || index >= _layers.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
-
-            _document.DecreaseGroupLayerIndexes(index);
-            _layers.RemoveAt(index);
-        }
-
-        public SerializableLayer Add(string name) => Add(name, 0, 0);
-
-        public SerializableLayer Add(string name, int width, int height, bool isVisible = true, float opacity = 1, int offsetX = 0, int offsetY = 0)
-        {
-            SerializableLayer layer = new SerializableLayer(width, height, offsetX, offsetY) { IsVisible = isVisible, Opacity = opacity, Name = name };
-            Add(layer);
-            return layer;
-        }
-
-        /// <summary>
-        /// Moves the <paramref name="layer"/> to the specified <paramref name="index"/>
-        /// </summary>
-        /// <param name="layer">The layer to move</param>
-        /// <param name="index">The index where the <paramref name="layer"/> should be moved to</param>
-        /// <returns>If the move operation was successfull (Returns false if the <paramref name="layer"/> couldn't be found)</returns>
-        public bool MoveTo(SerializableLayer layer, int index)
-        {
-            int layerIndex = IndexOf(layer);
-
-            if (layerIndex == -1 || index == -1)
+            if (!group.IsVisible)
             {
                 return false;
             }
-
-            RemoveAt(layerIndex);
-            Insert(index, layer);
-
-            return true;
         }
 
-        /// <summary>
-        /// Moves the <paramref name="toMove"/> layer below the <paramref name="target"/> layer
-        /// </summary>
-        /// <param name="toMove">The layer to move</param>
-        /// <param name="target">The layer which should appear above the <paramref name="toMove"/> layer</param>
-        /// <returns>If the move operation was successfull (Returns false if <paramref name="toMove"/> or <paramref name="target"/> couldn't be found)</returns>
-        public bool MoveBelow(SerializableLayer toMove, SerializableLayer target)
+        return true;
+    }
+
+    /// <summary>
+    /// Adds the <paramref name="layer"/> to the <paramref name="group"/>
+    /// <para/><b>Note: All layers between the <paramref name="layer"/> and the <see cref="SerializableGroup.StartLayer"/> or <see cref="SerializableGroup.EndLayer"/> will be added to the group too.</b>
+    /// </summary>
+    public void AddToGroup(SerializableGroup group, SerializableLayer layer)
+    {
+        int index = IndexOf(layer);
+
+        foreach (SerializableGroup groupStack in group.GetStack(_document))
         {
-            return MoveTo(toMove, IndexOf(target));
+            groupStack.EnsureInside(index);
+        }
+    }
+
+    /// <summary>
+    /// Returns true if the <paramref name="layer"/> is inside the <paramref name="group"/>
+    /// </summary>
+    public bool ContainedIn(SerializableGroup group, SerializableLayer layer)
+    {
+        return ContainedIn(group, IndexOf(layer));
+    }
+
+    /// <summary>
+    /// Get's the parents of the <paramref name="layer"/>
+    /// </summary>
+    /// <returns>Returns the hierachy of the parent groups or null when the layer wasn't found</returns>
+    public IEnumerable<SerializableGroup> GetGroups(SerializableLayer layer)
+    {
+        _ = TryGetGroups(layer, out var parents);
+        return parents;
+    }
+
+    /// <summary>
+    /// Tries to get the <paramref name="parents"/> of the <paramref name="layer"/>
+    /// </summary>
+    /// <returns>True if the layer was found</returns>
+    public bool TryGetGroups(SerializableLayer layer, out IEnumerable<SerializableGroup> parents)
+    {
+        int layerIndex = IndexOf(layer);
+
+        if (layerIndex == -1)
+        {
+            parents = null;
+            return false;
         }
 
-        /// <summary>
-        /// Moves the <paramref name="toMove"/> layer above the <paramref name="target"/> layer
-        /// </summary>
-        /// <param name="toMove">The layer to move</param>
-        /// <param name="target">The layer which should appear below the <paramref name="toMove"/> layer</param>
-        /// <returns>If the move operation was successfull (Returns false if <paramref name="toMove"/> or <paramref name="target"/> couldn't be found)</returns>
-        public bool MoveAbove(SerializableLayer toMove, SerializableLayer target)
+        Stack<SerializableGroup> groups = new();
+
+        GetGroups(layerIndex, _document.Groups, ref groups);
+
+        parents = groups;
+        return true;
+    }
+
+    private void GetGroups(int index, IEnumerable<SerializableGroup> subgroups, ref Stack<SerializableGroup> groups)
+    {
+        if (subgroups == null)
         {
-            return MoveTo(toMove, IndexOf(target) + 1);
+            return;
         }
 
-        /// <summary>
-        /// Get's the opacity of <paramref name="layer"/> respecting the opacity of the parent groups
-        /// </summary>
-        public double GetFinalLayerOpacity(SerializableLayer layer)
+        foreach (SerializableGroup group in subgroups)
         {
-            if (layer.Opacity == 0)
+            groups.Push(group);
+
+            if (ContainedIn(group, index))
             {
-                return 0f;
-            }
-
-            double finalOpacity = layer.Opacity;
-            var groups = GetGroups(layer);
-
-            if (groups == null)
-            {
-                throw new InvalidOperationException("The layer was not found in the layer collection.");
-            }
-
-            foreach (var group in groups)
-            {
-                finalOpacity *= group.Opacity;
-            }
-
-            return finalOpacity;
-        }
-
-        public bool GetFinalLayerVisibilty(SerializableLayer layer)
-        {
-            if (!layer.IsVisible)
-            {
-                return false;
-            }
-
-            var groups = GetGroups(layer);
-
-            if (groups == null)
-            {
-                throw new InvalidOperationException("The layer was not found in the layer collection.");
-            }
-
-            foreach (var group in groups)
-            {
-                if (!group.IsVisible)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Adds the <paramref name="layer"/> to the <paramref name="group"/>
-        /// <para/><b>Note: All layers between the <paramref name="layer"/> and the <see cref="SerializableGroup.StartLayer"/> or <see cref="SerializableGroup.EndLayer"/> will be added to the group too.</b>
-        /// </summary>
-        public void AddToGroup(SerializableGroup group, SerializableLayer layer)
-        {
-            int index = IndexOf(layer);
-
-            foreach (SerializableGroup groupStack in group.GetStack(_document))
-            {
-                groupStack.EnsureInside(index);
-            }
-        }
-
-        /// <summary>
-        /// Returns true if the <paramref name="layer"/> is inside the <paramref name="group"/>
-        /// </summary>
-        public bool ContainedIn(SerializableGroup group, SerializableLayer layer)
-        {
-            return ContainedIn(group, IndexOf(layer));
-        }
-
-        /// <summary>
-        /// Get's the parents of the <paramref name="layer"/>
-        /// </summary>
-        /// <returns>Returns the hierachy of the parent groups or null when the layer wasn't found</returns>
-        public IEnumerable<SerializableGroup> GetGroups(SerializableLayer layer)
-        {
-            _ = TryGetGroups(layer, out var parents);
-            return parents;
-        }
-
-        /// <summary>
-        /// Tries to get the <paramref name="parents"/> of the <paramref name="layer"/>
-        /// </summary>
-        /// <returns>True if the layer was found</returns>
-        public bool TryGetGroups(SerializableLayer layer, out IEnumerable<SerializableGroup> parents)
-        {
-            int layerIndex = IndexOf(layer);
-
-            if (layerIndex == -1)
-            {
-                parents = null;
-                return false;
-            }
-
-            Stack<SerializableGroup> groups = new();
-
-            GetGroups(layerIndex, _document.Groups, ref groups);
-
-            parents = groups;
-            return true;
-        }
-
-        private void GetGroups(int index, IEnumerable<SerializableGroup> subgroups, ref Stack<SerializableGroup> groups)
-        {
-            if (subgroups == null)
-            {
+                GetGroups(index, group.Subgroups, ref groups);
                 return;
             }
 
-            foreach (SerializableGroup group in subgroups)
-            {
-                groups.Push(group);
-
-                if (ContainedIn(group, index))
-                {
-                    GetGroups(index, group.Subgroups, ref groups);
-                    return;
-                }
-
-                groups.Pop();
-            }
+            groups.Pop();
         }
-
-        private bool ContainedIn(SerializableGroup group, int layerIndex)
-        {
-            return group.SerializedStartLayer <= layerIndex && layerIndex <= group.SerializedEndLayer;
-        }
-
-        /// <summary>
-        /// Gets the internal list instance
-        /// </summary>
-        internal List<SerializableLayer> GetList() => _layers;
     }
+
+    private bool ContainedIn(SerializableGroup group, int layerIndex)
+    {
+        return group.SerializedStartLayer <= layerIndex && layerIndex <= group.SerializedEndLayer;
+    }
+
+    /// <summary>
+    /// Gets the internal list instance
+    /// </summary>
+    internal List<SerializableLayer> GetList() => _layers;
 }

--- a/src/PixiParser/Collections/SwatchCollection.cs
+++ b/src/PixiParser/Collections/SwatchCollection.cs
@@ -1,83 +1,81 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Runtime.CompilerServices;
 
-namespace PixiEditor.Parser.Collections
+namespace PixiEditor.Parser.Collections;
+
+public class SwatchCollection : List<Color>
 {
-    public class SwatchCollection : List<Color>
+    public SwatchCollection()
+        : base()
+    { }
+
+    public SwatchCollection(int capacity)
+        : base(capacity)
+    { }
+
+    public SwatchCollection(IEnumerable<Color> colors)
+        : base(colors)
+    { }
+
+    public SwatchCollection(params Color[] colors)
+        : base(colors)
+    { }
+
+    public Color Add(byte r, byte g, byte b) => AddReturn(Color.FromArgb(r, g, b));
+
+    public Color Add(byte a, byte r, byte g, byte b) => AddReturn(Color.FromArgb(a, r, g, b));
+
+    public Color Add(int argb) => AddReturn(Color.FromArgb(argb));
+
+    private Color AddReturn(Color color)
     {
-        public SwatchCollection()
-            : base()
-        { }
+        Add(color);
+        return color;
+    }
 
-        public SwatchCollection(int capacity)
-            : base(capacity)
-        { }
-
-        public SwatchCollection(IEnumerable<Color> colors)
-            : base(colors)
-        { }
-
-        public SwatchCollection(params Color[] colors)
-            : base(colors)
-        { }
-
-        public Color Add(byte r, byte g, byte b) => AddReturn(Color.FromArgb(r, g, b));
-
-        public Color Add(byte a, byte r, byte g, byte b) => AddReturn(Color.FromArgb(a, r, g, b));
-
-        public Color Add(int argb) => AddReturn(Color.FromArgb(argb));
-
-        private Color AddReturn(Color color)
+    internal void FromByteArray(byte[] bytes)
+    {
+        if (bytes.Length % 4 != 0)
         {
-            Add(color);
-            return color;
+            throw new ArgumentOutOfRangeException("The length of the bytes must be a multiple of 4", nameof(bytes));
         }
 
-        internal void FromByteArray(byte[] bytes)
+        Clear();
+
+        Capacity = bytes.Length / 4;
+
+        for (int sI = 0; sI < bytes.Length; sI += 4)
         {
-            if (bytes.Length % 4 != 0)
-            {
-                throw new ArgumentOutOfRangeException("The length of the bytes must be a multiple of 4", nameof(bytes));
-            }
+            byte a = bytes[sI];
+            byte r = bytes[sI + 1];
+            byte g = bytes[sI + 2];
+            byte b = bytes[sI + 3];
 
-            Clear();
+            Add(a, r, g, b);
+        }
+    }
 
-            Capacity = bytes.Length / 4;
-
-            for (int sI = 0; sI < bytes.Length; sI += 4)
-            {
-                byte a = bytes[sI];
-                byte r = bytes[sI + 1];
-                byte g = bytes[sI + 2];
-                byte b = bytes[sI + 3];
-
-                Add(a, r, g, b);
-            }
+    internal byte[] ToByteArray()
+    {
+        if (Count == 0)
+        {
+            return Array.Empty<byte>();
         }
 
-        internal byte[] ToByteArray()
+        byte[] array = new byte[Count * 4];
+
+        for (int i = 0; i < Count; i++)
         {
-            if (Count == 0)
-            {
-                return Array.Empty<byte>();
-            }
+            int arrayIndex = i * 4;
+            Color swatch = this[i];
 
-            byte[] array = new byte[Count * 4];
-
-            for (int i = 0; i < Count; i++)
-            {
-                int arrayIndex = i * 4;
-                Color swatch = this[i];
-
-                array[arrayIndex] = swatch.A;
-                array[arrayIndex + 1] = swatch.R;
-                array[arrayIndex + 2] = swatch.G;
-                array[arrayIndex + 3] = swatch.B;
-            }
-
-            return array;
+            array[arrayIndex] = swatch.A;
+            array[arrayIndex + 1] = swatch.R;
+            array[arrayIndex + 2] = swatch.G;
+            array[arrayIndex + 3] = swatch.B;
         }
+
+        return array;
     }
 }

--- a/src/PixiParser/Exceptions/InvalidFileException.cs
+++ b/src/PixiParser/Exceptions/InvalidFileException.cs
@@ -1,16 +1,14 @@
 ﻿using System;
 
-namespace PixiEditor.Parser
-{
+namespace PixiEditor.Parser;
 
-    [Serializable]
-    public class InvalidFileException : Exception
-    {
-        public InvalidFileException() { }
-        public InvalidFileException(string message) : base(message) { }
-        public InvalidFileException(string message, Exception inner) : base(message, inner) { }
-        protected InvalidFileException(
-          System.Runtime.Serialization.SerializationInfo info,
-          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-    }
+[Serializable]
+public class InvalidFileException : Exception
+{
+    public InvalidFileException() { }
+    public InvalidFileException(string message) : base(message) { }
+    public InvalidFileException(string message, Exception inner) : base(message, inner) { }
+    protected InvalidFileException(
+      System.Runtime.Serialization.SerializationInfo info,
+      System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
 }

--- a/src/PixiParser/Exceptions/OldFileFormatException.cs
+++ b/src/PixiParser/Exceptions/OldFileFormatException.cs
@@ -1,16 +1,14 @@
 ﻿using System;
 
-namespace PixiEditor.Parser
-{
+namespace PixiEditor.Parser;
 
-    [Serializable]
-    public class OldFileFormatException : Exception
-    {
-        public OldFileFormatException() { }
-        public OldFileFormatException(string message) : base(message) { }
-        public OldFileFormatException(string message, Exception inner) : base(message, inner) { }
-        protected OldFileFormatException(
-          System.Runtime.Serialization.SerializationInfo info,
-          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-    }
+[Serializable]
+public class OldFileFormatException : Exception
+{
+    public OldFileFormatException() { }
+    public OldFileFormatException(string message) : base(message) { }
+    public OldFileFormatException(string message, Exception inner) : base(message, inner) { }
+    protected OldFileFormatException(
+      System.Runtime.Serialization.SerializationInfo info,
+      System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
 }

--- a/src/PixiParser/Helpers/LayerHelpers.cs
+++ b/src/PixiParser/Helpers/LayerHelpers.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace PixiEditor.Parser.Helpers;
 
-namespace PixiEditor.Parser.Helpers
+public static class LayerHelpers
 {
-    public static class LayerHelpers
-    {
-        public static bool GetFinalVisibility(this SerializableLayer layer, SerializableDocument document) => document.Layers.GetFinalLayerVisibilty(layer);
+    public static bool GetFinalVisibility(this SerializableLayer layer, SerializableDocument document) => document.Layers.GetFinalLayerVisibilty(layer);
 
-        public static double GetFinalOpacity(this SerializableLayer layer, SerializableDocument document) => document.Layers.GetFinalLayerOpacity(layer);
-    }
+    public static double GetFinalOpacity(this SerializableLayer layer, SerializableDocument document) => document.Layers.GetFinalLayerOpacity(layer);
 }

--- a/src/PixiParser/Helpers/StructureHelpers.cs
+++ b/src/PixiParser/Helpers/StructureHelpers.cs
@@ -1,103 +1,102 @@
 ﻿using System.Collections.Generic;
 using static System.Math;
 
-namespace PixiEditor.Parser.Helpers
+namespace PixiEditor.Parser.Helpers;
+
+internal static class StructureHelpers
 {
-    internal static class StructureHelpers
+    public static void ClearGroupLayerIndexes(this SerializableDocument document)
     {
-        public static void ClearGroupLayerIndexes(this SerializableDocument document)
+        foreach (SerializableGroup group in document.Groups)
         {
-            foreach (SerializableGroup group in document.Groups)
+            group.SerializedStartLayer = group.SerializedEndLayer = -1;
+        }
+    }
+
+    public static void IncreaseGroupLayerIndexes(this SerializableDocument document, int start)
+    {
+        foreach (SerializableGroup group in document.Groups)
+        {
+            if (group.SerializedStartLayer >= start)
             {
-                group.SerializedStartLayer = group.SerializedEndLayer = -1;
+                group.SerializedStartLayer++;
+            }
+
+            if (group.SerializedEndLayer >= start)
+            {
+                group.SerializedStartLayer++;
             }
         }
+    }
 
-        public static void IncreaseGroupLayerIndexes(this SerializableDocument document, int start)
+    public static void DecreaseGroupLayerIndexes(this SerializableDocument document, int start)
+    {
+        foreach (SerializableGroup group in document.Groups)
         {
-            foreach (SerializableGroup group in document.Groups)
+            if (group.SerializedStartLayer > start)
             {
-                if (group.SerializedStartLayer >= start)
-                {
-                    group.SerializedStartLayer++;
-                }
+                group.SerializedStartLayer = Max(group.SerializedStartLayer - 1, -1);
+            }
 
-                if (group.SerializedEndLayer >= start)
-                {
-                    group.SerializedStartLayer++;
-                }
+            if (group.SerializedEndLayer > start)
+            {
+                group.SerializedEndLayer = Max(group.SerializedEndLayer - 1, -1);
             }
         }
+    }
 
-        public static void DecreaseGroupLayerIndexes(this SerializableDocument document, int start)
+    public static void EnsureInside(this SerializableGroup group, int index)
+    {
+        if (group.SerializedStartLayer == -1)
         {
-            foreach (SerializableGroup group in document.Groups)
-            {
-                if (group.SerializedStartLayer > start)
-                {
-                    group.SerializedStartLayer = Max(group.SerializedStartLayer - 1, -1);
-                }
-
-                if (group.SerializedEndLayer > start)
-                {
-                    group.SerializedEndLayer = Max(group.SerializedEndLayer - 1, -1);
-                }
-            }
+            group.SerializedStartLayer = index;
+        }
+        else
+        {
+            group.SerializedStartLayer = Min(group.SerializedStartLayer, index);
         }
 
-        public static void EnsureInside(this SerializableGroup group, int index)
+        if (group.SerializedEndLayer == -1)
         {
-            if (group.SerializedStartLayer == -1)
-            {
-                group.SerializedStartLayer = index;
-            }
-            else
-            {
-                group.SerializedStartLayer = Min(group.SerializedStartLayer, index);
-            }
+            group.SerializedEndLayer = index;
+        }
+        else
+        {
+            group.SerializedEndLayer = Max(group.SerializedEndLayer, index);
+        }
+    }
 
-            if (group.SerializedEndLayer == -1)
-            {
-                group.SerializedEndLayer = index;
-            }
-            else
-            {
-                group.SerializedEndLayer = Max(group.SerializedEndLayer, index);
-            }
+    public static IEnumerable<SerializableGroup> GetStack(this SerializableGroup group, SerializableDocument document)
+    {
+        Stack<SerializableGroup> groups = new();
+
+        if (ContainedIn(group, document.Groups, ref groups))
+        {
+            return groups;
         }
 
-        public static IEnumerable<SerializableGroup> GetStack(this SerializableGroup group, SerializableDocument document)
-        {
-            Stack<SerializableGroup> groups = new();
+        return null;
+    }
 
-            if (ContainedIn(group, document.Groups, ref groups))
+    private static bool ContainedIn(SerializableGroup searchingFor, IEnumerable<SerializableGroup> searchingIn, ref Stack<SerializableGroup> groups)
+    {
+        foreach (SerializableGroup subgroup in searchingIn)
+        {
+            groups.Push(subgroup);
+
+            if (subgroup == searchingFor)
             {
-                return groups;
+                return true;
             }
 
-            return null;
-        }
-
-        private static bool ContainedIn(SerializableGroup searchingFor, IEnumerable<SerializableGroup> searchingIn, ref Stack<SerializableGroup> groups)
-        {
-            foreach (SerializableGroup subgroup in searchingIn)
+            if (subgroup.Subgroups != null && ContainedIn(searchingFor, subgroup.Subgroups, ref groups))
             {
-                groups.Push(subgroup);
-
-                if (subgroup == searchingFor)
-                {
-                    return true;
-                }
-
-                if (subgroup.Subgroups != null && ContainedIn(searchingFor, subgroup.Subgroups, ref groups))
-                {
-                    return true;
-                }
-
-                groups.Pop();
+                return true;
             }
 
-            return false;
+            groups.Pop();
         }
+
+        return false;
     }
 }

--- a/src/PixiParser/Models/SerializableDocument.cs
+++ b/src/PixiParser/Models/SerializableDocument.cs
@@ -5,190 +5,189 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 
-namespace PixiEditor.Parser
+namespace PixiEditor.Parser;
+
+[DataContract]
+public class SerializableDocument : IEnumerable<SerializableLayer>
 {
-    [DataContract]
-    public class SerializableDocument : IEnumerable<SerializableLayer>
+    private SwatchCollection swatchCollection;
+    private LayerCollection layerCollection;
+
+    /// <summary>
+    /// Set to the <see cref="PixiParser.FileVersion"/> when serializing
+    /// </summary>
+    [DataMember(Order = 4)]
+    public Version FileVersion { get; internal set; }
+
+    /// <summary>
+    /// The width of the document
+    /// </summary>
+    [DataMember(Order = 0)]
+    public int Width { get; set; }
+
+    /// <summary>
+    /// The height of the document
+    /// </summary>
+    [DataMember(Order = 1)]
+    public int Height { get; set; }
+
+    /// <summary>
+    /// A byte array containing all the swatches
+    /// </summary>
+    [DataMember(Order = 2)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Used in message pack")]
+    private byte[] SwatchesData { get => GetSwatchesBytes(); set => Swatches.FromByteArray(value); }
+
+    /// <summary>
+    /// A collection of swatches used in the document
+    /// </summary>
+    [IgnoreDataMember]
+    public SwatchCollection Swatches
     {
-        private SwatchCollection swatchCollection;
-        private LayerCollection layerCollection;
-
-        /// <summary>
-        /// Set to the <see cref="PixiParser.FileVersion"/> when serializing
-        /// </summary>
-        [DataMember(Order = 4)]
-        public Version FileVersion { get; internal set; }
-
-        /// <summary>
-        /// The width of the document
-        /// </summary>
-        [DataMember(Order = 0)]
-        public int Width { get; set; }
-
-        /// <summary>
-        /// The height of the document
-        /// </summary>
-        [DataMember(Order = 1)]
-        public int Height { get; set; }
-
-        /// <summary>
-        /// A byte array containing all the swatches
-        /// </summary>
-        [DataMember(Order = 2)]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Used in message pack")]
-        private byte[] SwatchesData { get => GetSwatchesBytes(); set => Swatches.FromByteArray(value); }
-
-        /// <summary>
-        /// A collection of swatches used in the document
-        /// </summary>
-        [IgnoreDataMember]
-        public SwatchCollection Swatches
+        get
         {
-            get
+            if (swatchCollection == null)
             {
-                if (swatchCollection == null)
-                {
-                    return swatchCollection = new SwatchCollection();
-                }
-
-                return swatchCollection;
-            }
-            internal set => swatchCollection = value;
-        }
-
-        [DataMember(Order = 3)]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Used in message pack")]
-        private List<SerializableLayer> SerializedLayers
-        { 
-            get
-            {
-                if (layerCollection == null)
-                {
-                    return new List<SerializableLayer>(0);
-                }
-
-                return layerCollection.GetList();
-            }
-            set
-            {
-                Layers = new LayerCollection(this, value);
-            }
-        }
-
-        /// <summary>
-        /// The layers contained in the document
-        /// </summary>
-        [IgnoreDataMember]
-        public LayerCollection Layers
-        {
-            get
-            {
-                if (layerCollection == null)
-                {
-                    return layerCollection = new LayerCollection(this);
-                }
-
-                return layerCollection;
-            }
-            private set => layerCollection = value;
-        }
-
-        /// <summary>
-        /// The layer groups
-        /// </summary>
-        [DataMember(Order = 5)]
-        public List<SerializableGroup> Groups { get; set; }
-
-        /// <summary>
-        /// Creates a new empty document
-        /// </summary>
-        public SerializableDocument()
-        {
-            Groups = new List<SerializableGroup>();
-        }
-
-        /// <summary>
-        /// Creates a new empty document
-        /// </summary>
-        public SerializableDocument(int width, int height)
-        {
-            Width = width;
-            Height = height;
-        }
-
-        /// <summary>
-        /// Creates a new document, with the <paramref name="layers"/> as it's layers
-        /// </summary>
-        public SerializableDocument(int width, int height, params SerializableLayer[] layers)
-            : this(width, height)
-        {
-            Layers = new LayerCollection(this, layers);
-        }
-
-        /// <summary>
-        /// Creates a new document, with the <paramref name="groups"/> as it's groups and the <paramref name="layers"/> as it's layers
-        /// </summary>
-        public SerializableDocument(int width, int height, IEnumerable<SerializableGroup> groups, params SerializableLayer[] layers)
-            : this(width, height)
-        {
-            Layers = new LayerCollection(this, layers);
-            Groups = new List<SerializableGroup>(groups);
-        }
-
-        /// <summary>
-        /// Creates a new document, with the <paramref name="layers"/> as it's layers
-        /// </summary>
-        public SerializableDocument(int width, int height, IEnumerable<SerializableLayer> layers)
-            : this(width, height)
-        {
-            Layers = new LayerCollection(this, layers);
-        }
-
-        /// <summary>
-        /// Creates a new document, with the <paramref name="groups"/> as it's groups and the <paramref name="layers"/> as it's layers
-        /// </summary>
-        public SerializableDocument(int width, int height, IEnumerable<SerializableGroup> groups, IEnumerable<SerializableLayer> layers)
-            : this(width, height)
-        {
-            Layers = new LayerCollection(this, layers);
-            Groups = new List<SerializableGroup>(groups);
-        }
-
-        public IEnumerator<SerializableLayer> GetEnumerator() => Layers.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => Layers.GetEnumerator();
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(FileVersion, Width, Height, swatchCollection, layerCollection, Groups);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is not SerializableDocument document)
-            {
-                return false;
+                return swatchCollection = new SwatchCollection();
             }
 
-            return Equals(document);
+            return swatchCollection;
         }
+        internal set => swatchCollection = value;
+    }
 
-        protected virtual bool Equals(SerializableDocument document)
+    [DataMember(Order = 3)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Used in message pack")]
+    private List<SerializableLayer> SerializedLayers
+    {
+        get
         {
-            return FileVersion == document.FileVersion && Width == document.Width && Height == document.Height &&
-                   (swatchCollection == null && document.swatchCollection == null || swatchCollection.SequenceEqual(document.swatchCollection)) &&
-                   (layerCollection == null && document.layerCollection == null || layerCollection.SequenceEqual(document.layerCollection)) &&
-                   (Groups == null && document.Groups == null || Groups.SequenceEqual(document.Groups));
-        }
-
-        private byte[] GetSwatchesBytes()
-        {
-            if (Swatches is null)
+            if (layerCollection == null)
             {
-                return Array.Empty<byte>();
+                return new List<SerializableLayer>(0);
             }
 
-            return Swatches.ToByteArray();
+            return layerCollection.GetList();
         }
+        set
+        {
+            Layers = new LayerCollection(this, value);
+        }
+    }
+
+    /// <summary>
+    /// The layers contained in the document
+    /// </summary>
+    [IgnoreDataMember]
+    public LayerCollection Layers
+    {
+        get
+        {
+            if (layerCollection == null)
+            {
+                return layerCollection = new LayerCollection(this);
+            }
+
+            return layerCollection;
+        }
+        private set => layerCollection = value;
+    }
+
+    /// <summary>
+    /// The layer groups
+    /// </summary>
+    [DataMember(Order = 5)]
+    public List<SerializableGroup> Groups { get; set; }
+
+    /// <summary>
+    /// Creates a new empty document
+    /// </summary>
+    public SerializableDocument()
+    {
+        Groups = new List<SerializableGroup>();
+    }
+
+    /// <summary>
+    /// Creates a new empty document
+    /// </summary>
+    public SerializableDocument(int width, int height)
+    {
+        Width = width;
+        Height = height;
+    }
+
+    /// <summary>
+    /// Creates a new document, with the <paramref name="layers"/> as it's layers
+    /// </summary>
+    public SerializableDocument(int width, int height, params SerializableLayer[] layers)
+        : this(width, height)
+    {
+        Layers = new LayerCollection(this, layers);
+    }
+
+    /// <summary>
+    /// Creates a new document, with the <paramref name="groups"/> as it's groups and the <paramref name="layers"/> as it's layers
+    /// </summary>
+    public SerializableDocument(int width, int height, IEnumerable<SerializableGroup> groups, params SerializableLayer[] layers)
+        : this(width, height)
+    {
+        Layers = new LayerCollection(this, layers);
+        Groups = new List<SerializableGroup>(groups);
+    }
+
+    /// <summary>
+    /// Creates a new document, with the <paramref name="layers"/> as it's layers
+    /// </summary>
+    public SerializableDocument(int width, int height, IEnumerable<SerializableLayer> layers)
+        : this(width, height)
+    {
+        Layers = new LayerCollection(this, layers);
+    }
+
+    /// <summary>
+    /// Creates a new document, with the <paramref name="groups"/> as it's groups and the <paramref name="layers"/> as it's layers
+    /// </summary>
+    public SerializableDocument(int width, int height, IEnumerable<SerializableGroup> groups, IEnumerable<SerializableLayer> layers)
+        : this(width, height)
+    {
+        Layers = new LayerCollection(this, layers);
+        Groups = new List<SerializableGroup>(groups);
+    }
+
+    public IEnumerator<SerializableLayer> GetEnumerator() => Layers.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => Layers.GetEnumerator();
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(FileVersion, Width, Height, swatchCollection, layerCollection, Groups);
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (obj is not SerializableDocument document)
+        {
+            return false;
+        }
+
+        return Equals(document);
+    }
+
+    protected virtual bool Equals(SerializableDocument document)
+    {
+        return FileVersion == document.FileVersion && Width == document.Width && Height == document.Height &&
+               (swatchCollection == null && document.swatchCollection == null || swatchCollection.SequenceEqual(document.swatchCollection)) &&
+               (layerCollection == null && document.layerCollection == null || layerCollection.SequenceEqual(document.layerCollection)) &&
+               (Groups == null && document.Groups == null || Groups.SequenceEqual(document.Groups));
+    }
+
+    private byte[] GetSwatchesBytes()
+    {
+        if (Swatches is null)
+        {
+            return Array.Empty<byte>();
+        }
+
+        return Swatches.ToByteArray();
     }
 }

--- a/src/PixiParser/Models/SerializableGroup.cs
+++ b/src/PixiParser/Models/SerializableGroup.cs
@@ -4,158 +4,157 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Serialization;
 
-namespace PixiEditor.Parser
+namespace PixiEditor.Parser;
+
+[DataContract]
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public class SerializableGroup
 {
-    [DataContract]
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public class SerializableGroup
+    /// <summary>
+    /// The name of the group
+    /// </summary>
+    [DataMember(Order = 0)]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// The subgroups of this group
+    /// </summary>
+    [DataMember(Order = 1)]
+    public List<SerializableGroup> Subgroups { get; set; }
+
+    /// <summary>
+    /// Should all the layer in the group be visible
+    /// </summary>
+    [DataMember(Order = 2)]
+    public bool IsVisible { get; set; }
+
+    /// <summary>
+    /// Opacity of the group
+    /// </summary>
+    [DataMember(Order = 3)]
+    public float Opacity { get; set; }
+
+    [DataMember(Order = 4)]
+    internal int SerializedStartLayer { get; set; }
+
+    [DataMember(Order = 5)]
+    internal int SerializedEndLayer { get; set; }
+
+    /// <summary>
+    /// The index of the first layer in the group
+    /// </summary>
+    [IgnoreDataMember]
+    public int StartLayer
     {
-        /// <summary>
-        /// The name of the group
-        /// </summary>
-        [DataMember(Order = 0)]
-        public string Name { get; set; }
-
-        /// <summary>
-        /// The subgroups of this group
-        /// </summary>
-        [DataMember(Order = 1)]
-        public List<SerializableGroup> Subgroups { get; set; }
-
-        /// <summary>
-        /// Should all the layer in the group be visible
-        /// </summary>
-        [DataMember(Order = 2)]
-        public bool IsVisible { get; set; }
-
-        /// <summary>
-        /// Opacity of the group
-        /// </summary>
-        [DataMember(Order = 3)]
-        public float Opacity { get; set; }
-
-        [DataMember(Order = 4)]
-        internal int SerializedStartLayer { get; set; }
-
-        [DataMember(Order = 5)]
-        internal int SerializedEndLayer { get; set; }
-
-        /// <summary>
-        /// The index of the first layer in the group
-        /// </summary>
-        [IgnoreDataMember]
-        public int StartLayer
+        get => SerializedStartLayer;
+        set
         {
-            get => SerializedStartLayer;
-            set
+            if (value < 0)
             {
-                if (value < 0)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(value), $"value must be between 0 and {nameof(int.MaxValue)}");
-                }
-
-                SerializedEndLayer = Math.Max(SerializedEndLayer, value);
-                SerializedStartLayer = value;
-            }
-        }
-
-        /// <summary>
-        /// The index of the last layer in the group
-        /// </summary>
-        [IgnoreDataMember]
-        public int EndLayer
-        {
-            get => SerializedEndLayer;
-            set
-            {
-                if (value < 0)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(value), $"value must be between 0 and {nameof(int.MaxValue)}");
-                }
-
-                SerializedStartLayer = Math.Min(SerializedStartLayer, value);
-                SerializedEndLayer = value;
-            }
-        }
-
-        public SerializableGroup()
-        {
-            Subgroups = new List<SerializableGroup>();
-            IsVisible = true;
-            Opacity = 1;
-            SerializedStartLayer = -1;
-            SerializedEndLayer = -1;
-        }
-
-        public SerializableGroup(string name)
-            : this()
-        {
-            Name = name;
-        }
-
-        public SerializableGroup(string name, IEnumerable<SerializableGroup> subgroups)
-            : this()
-        {
-            Name = name;
-            Subgroups = new List<SerializableGroup>(subgroups);
-        }
-
-        public SerializableGroup(string name, int startLayerIndex, int endLayerIndex, IEnumerable<SerializableGroup> subgroups, bool isVisible = true, float opacity = 1)
-            : this(name)
-        {
-            if (startLayerIndex > endLayerIndex)
-            {
-                throw new ArgumentException("The start layer index can't be lower then the end layer index", nameof(startLayerIndex));
+                throw new ArgumentOutOfRangeException(nameof(value), $"value must be between 0 and {nameof(int.MaxValue)}");
             }
 
-            Name = name;
-            SerializedStartLayer = startLayerIndex;
-            SerializedEndLayer = endLayerIndex;
-            Subgroups = new List<SerializableGroup>(subgroups);
-            IsVisible = isVisible;
-            Opacity = opacity;
+            SerializedEndLayer = Math.Max(SerializedEndLayer, value);
+            SerializedStartLayer = value;
         }
-
-        /// <summary>
-        /// Set's the values of <see cref="StartLayer"/> and <see cref="EndLayer"/> in this <em>group</em> and all <em>subgroups</em> to -1
-        /// </summary>
-        public void DetachLayers()
-        {
-            DetachLayers(this);
-        }
-
-        private static void DetachLayers(SerializableGroup group)
-        {
-            group.SerializedEndLayer = -1;
-            group.SerializedStartLayer = -1;
-
-            foreach (SerializableGroup subgroup in group.Subgroups)
-            {
-                DetachLayers(subgroup);
-            }
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Name, Subgroups, IsVisible, Opacity, StartLayer, EndLayer);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is not SerializableGroup group)
-            {
-                return false;
-            }
-
-            return Equals(group);
-        }
-
-        protected virtual bool Equals(SerializableGroup group)
-        {
-            return Name == group.Name && (Subgroups != null && group.Subgroups != null || Subgroups.SequenceEqual(group.Subgroups) &&
-                   IsVisible == group.IsVisible && Opacity == group.Opacity && StartLayer == group.StartLayer && EndLayer == group.EndLayer);
-        }
-
-        private string DebuggerDisplay => $"'{Name}' Start: {StartLayer} End: {EndLayer}";
     }
+
+    /// <summary>
+    /// The index of the last layer in the group
+    /// </summary>
+    [IgnoreDataMember]
+    public int EndLayer
+    {
+        get => SerializedEndLayer;
+        set
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), $"value must be between 0 and {nameof(int.MaxValue)}");
+            }
+
+            SerializedStartLayer = Math.Min(SerializedStartLayer, value);
+            SerializedEndLayer = value;
+        }
+    }
+
+    public SerializableGroup()
+    {
+        Subgroups = new List<SerializableGroup>();
+        IsVisible = true;
+        Opacity = 1;
+        SerializedStartLayer = -1;
+        SerializedEndLayer = -1;
+    }
+
+    public SerializableGroup(string name)
+        : this()
+    {
+        Name = name;
+    }
+
+    public SerializableGroup(string name, IEnumerable<SerializableGroup> subgroups)
+        : this()
+    {
+        Name = name;
+        Subgroups = new List<SerializableGroup>(subgroups);
+    }
+
+    public SerializableGroup(string name, int startLayerIndex, int endLayerIndex, IEnumerable<SerializableGroup> subgroups, bool isVisible = true, float opacity = 1)
+        : this(name)
+    {
+        if (startLayerIndex > endLayerIndex)
+        {
+            throw new ArgumentException("The start layer index can't be lower then the end layer index", nameof(startLayerIndex));
+        }
+
+        Name = name;
+        SerializedStartLayer = startLayerIndex;
+        SerializedEndLayer = endLayerIndex;
+        Subgroups = new List<SerializableGroup>(subgroups);
+        IsVisible = isVisible;
+        Opacity = opacity;
+    }
+
+    /// <summary>
+    /// Set's the values of <see cref="StartLayer"/> and <see cref="EndLayer"/> in this <em>group</em> and all <em>subgroups</em> to -1
+    /// </summary>
+    public void DetachLayers()
+    {
+        DetachLayers(this);
+    }
+
+    private static void DetachLayers(SerializableGroup group)
+    {
+        group.SerializedEndLayer = -1;
+        group.SerializedStartLayer = -1;
+
+        foreach (SerializableGroup subgroup in group.Subgroups)
+        {
+            DetachLayers(subgroup);
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Name, Subgroups, IsVisible, Opacity, StartLayer, EndLayer);
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (obj is not SerializableGroup group)
+        {
+            return false;
+        }
+
+        return Equals(group);
+    }
+
+    protected virtual bool Equals(SerializableGroup group)
+    {
+        return Name == group.Name && (Subgroups != null && group.Subgroups != null || Subgroups.SequenceEqual(group.Subgroups) &&
+               IsVisible == group.IsVisible && Opacity == group.Opacity && StartLayer == group.StartLayer && EndLayer == group.EndLayer);
+    }
+
+    private string DebuggerDisplay => $"'{Name}' Start: {StartLayer} End: {EndLayer}";
 }

--- a/src/PixiParser/Models/SerializableLayer.cs
+++ b/src/PixiParser/Models/SerializableLayer.cs
@@ -3,133 +3,132 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Serialization;
 
-namespace PixiEditor.Parser
+namespace PixiEditor.Parser;
+
+[DataContract]
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public class SerializableLayer
 {
-    [DataContract]
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public class SerializableLayer
+    private float opacity;
+
+    /// <summary>
+    /// The width of the layer
+    /// </summary>
+    [DataMember(Order = 0)]
+    public int Width { get; set; }
+
+    /// <summary>
+    /// The height of the layer
+    /// </summary>
+    [DataMember(Order = 1)]
+    public int Height { get; set; }
+
+    /// <summary>
+    /// The X offset of the layer
+    /// </summary>
+    [DataMember(Order = 2)]
+    public int OffsetX { get; set; }
+
+    /// <summary>
+    /// The Y offset of the layer
+    /// </summary>
+    [DataMember(Order = 3)]
+    public int OffsetY { get; set; }
+
+    /// <summary>
+    /// The name of the layer
+    /// </summary>
+    [DataMember(Order = 4)]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Shoud the layer be visible
+    /// </summary>
+    [DataMember(Order = 5)]
+    public bool IsVisible { get; set; }
+
+    /// <summary>
+    /// The opacity of the layer
+    /// </summary>
+    [DataMember(Order = 6)]
+    public float Opacity
     {
-        private float opacity;
-
-        /// <summary>
-        /// The width of the layer
-        /// </summary>
-        [DataMember(Order = 0)]
-        public int Width { get; set; }
-
-        /// <summary>
-        /// The height of the layer
-        /// </summary>
-        [DataMember(Order = 1)]
-        public int Height { get; set; }
-
-        /// <summary>
-        /// The X offset of the layer
-        /// </summary>
-        [DataMember(Order = 2)]
-        public int OffsetX { get; set; }
-
-        /// <summary>
-        /// The Y offset of the layer
-        /// </summary>
-        [DataMember(Order = 3)]
-        public int OffsetY { get; set; }
-
-        /// <summary>
-        /// The name of the layer
-        /// </summary>
-        [DataMember(Order = 4)]
-        public string Name { get; set; }
-
-        /// <summary>
-        /// Shoud the layer be visible
-        /// </summary>
-        [DataMember(Order = 5)]
-        public bool IsVisible { get; set; }
-
-        /// <summary>
-        /// The opacity of the layer
-        /// </summary>
-        [DataMember(Order = 6)]
-        public float Opacity
+        get => opacity;
+        set
         {
-            get => opacity;
-            set
+            opacity = value switch
             {
-                opacity = value switch
-                {
-                    > 1f => 1f,
-                    < 0f => 0f,
-                    _ => value,
-                };
-            }
+                > 1f => 1f,
+                < 0f => 0f,
+                _ => value,
+            };
         }
-
-        /// <summary>
-        /// The png data of the layer
-        /// </summary>
-        [DataMember(Order = 7)]
-        public byte[] PngBytes { get; set; }
-
-        /// <summary>
-        /// Creates a new <see cref="SerializableLayer"/> that is set to visible and has a <see cref="Opacity"/> of 1
-        /// </summary>
-        public SerializableLayer()
-        {
-            IsVisible = true;
-            Opacity = 1;
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="SerializableLayer"/> that is set to visible and has a <see cref="Opacity"/> of 1
-        /// </summary>
-        public SerializableLayer(int width, int height)
-            : this()
-        {
-            Width = width;
-            Height = height;
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="SerializableLayer"/> that is set to visible and has a <see cref="Opacity"/> of 1
-        /// </summary>
-        public SerializableLayer(int width, int height, int offsetX, int offsetY)
-            : this(width, height)
-        {
-            OffsetX = offsetX;
-            OffsetY = offsetY;
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is not SerializableLayer layer)
-            {
-                return false;
-            }
-
-            return Equals(layer);
-        }
-
-        public override int GetHashCode()
-        {
-            HashCode hashCode = default;
-            hashCode.Add(Name);
-            hashCode.Add(Width);
-            hashCode.Add(Height);
-            hashCode.Add(PngBytes);
-            hashCode.Add(IsVisible);
-            hashCode.Add(OffsetX);
-            hashCode.Add(OffsetY);
-            hashCode.Add(Opacity);
-            return hashCode.ToHashCode();
-        }
-
-        protected bool Equals(SerializableLayer other)
-        {
-            return Name == other.Name && Width == other.Width && Height == other.Height && (PngBytes == null && other.PngBytes == null || PngBytes.SequenceEqual(other.PngBytes)) && 
-                   IsVisible == other.IsVisible && OffsetX == other.OffsetX && OffsetY == other.OffsetY && Opacity.Equals(other.Opacity);
-        }
-
-        private string DebuggerDisplay => $"'{Name}' {Width}x{Height}";
     }
+
+    /// <summary>
+    /// The png data of the layer
+    /// </summary>
+    [DataMember(Order = 7)]
+    public byte[] PngBytes { get; set; }
+
+    /// <summary>
+    /// Creates a new <see cref="SerializableLayer"/> that is set to visible and has a <see cref="Opacity"/> of 1
+    /// </summary>
+    public SerializableLayer()
+    {
+        IsVisible = true;
+        Opacity = 1;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="SerializableLayer"/> that is set to visible and has a <see cref="Opacity"/> of 1
+    /// </summary>
+    public SerializableLayer(int width, int height)
+        : this()
+    {
+        Width = width;
+        Height = height;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="SerializableLayer"/> that is set to visible and has a <see cref="Opacity"/> of 1
+    /// </summary>
+    public SerializableLayer(int width, int height, int offsetX, int offsetY)
+        : this(width, height)
+    {
+        OffsetX = offsetX;
+        OffsetY = offsetY;
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (obj is not SerializableLayer layer)
+        {
+            return false;
+        }
+
+        return Equals(layer);
+    }
+
+    public override int GetHashCode()
+    {
+        HashCode hashCode = default;
+        hashCode.Add(Name);
+        hashCode.Add(Width);
+        hashCode.Add(Height);
+        hashCode.Add(PngBytes);
+        hashCode.Add(IsVisible);
+        hashCode.Add(OffsetX);
+        hashCode.Add(OffsetY);
+        hashCode.Add(Opacity);
+        return hashCode.ToHashCode();
+    }
+
+    protected bool Equals(SerializableLayer other)
+    {
+        return Name == other.Name && Width == other.Width && Height == other.Height && (PngBytes == null && other.PngBytes == null || PngBytes.SequenceEqual(other.PngBytes)) &&
+               IsVisible == other.IsVisible && OffsetX == other.OffsetX && OffsetY == other.OffsetY && Opacity.Equals(other.Opacity);
+    }
+
+    private string DebuggerDisplay => $"'{Name}' {Width}x{Height}";
 }

--- a/src/PixiParser/Parser/PixiParser.Deserialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Deserialize.cs
@@ -1,156 +1,154 @@
 ﻿using MessagePack;
-using PixiEditor.Parser.Helpers;
 using System;
 using System.IO;
 using System.Linq;
 
-namespace PixiEditor.Parser
+namespace PixiEditor.Parser;
+
+public static partial class PixiParser
 {
-    public static partial class PixiParser
+    static readonly byte[] oldFormatIdentifier =
+        new byte[] { 0x41, 0x50, 0x69, 0x78, 0x69, 0x45, 0x64, 0x69 };
+
+    /// <summary>
+    /// Deserializes a stream containing a .pixi file to a <see cref="SerializableDocument"/>.
+    /// </summary>
+    /// <returns>The deserialized document.</returns>
+    public static SerializableDocument Deserialize(Stream stream) => Deserialize(stream, out _);
+
+    // Version when the layer bitmap were not stored in the message pack
+    private static readonly Version parseLayerVersion = new(2, 0);
+
+    /// <summary>
+    /// Deserializes a stream containing a .pixi file to a <see cref="SerializableDocument"/>.
+    /// </summary>
+    /// <param name="stream">The stream to deserialize from</param>
+    /// <param name="bytesRead">The total number of bytes read from the stream</param>
+    /// <returns>The deserialized document.</returns>
+    public static SerializableDocument Deserialize(Stream stream, out int bytesRead)
     {
-        static readonly byte[] oldFormatIdentifier =
-            new byte[] { 0x41, 0x50, 0x69, 0x78, 0x69, 0x45, 0x64, 0x69 };
+        ThrowIfOldFormat(stream);
 
-        /// <summary>
-        /// Deserializes a stream containing a .pixi file to a <see cref="SerializableDocument"/>.
-        /// </summary>
-        /// <returns>The deserialized document.</returns>
-        public static SerializableDocument Deserialize(Stream stream) => Deserialize(stream, out _);
+        byte[] msgPack = GetMessagePack(stream, out bytesRead);
 
-        // Version when the layer bitmap were not stored in the message pack
-        private static readonly Version parseLayerVersion = new(2, 0);
+        SerializableDocument document = ParseDocument(msgPack);
 
-        /// <summary>
-        /// Deserializes a stream containing a .pixi file to a <see cref="SerializableDocument"/>.
-        /// </summary>
-        /// <param name="stream">The stream to deserialize from</param>
-        /// <param name="bytesRead">The total number of bytes read from the stream</param>
-        /// <returns>The deserialized document.</returns>
-        public static SerializableDocument Deserialize(Stream stream, out int bytesRead)
+        if (document.FileVersion < parseLayerVersion)
         {
-            ThrowIfOldFormat(stream);
-
-            byte[] msgPack = GetMessagePack(stream, out bytesRead);
-
-            SerializableDocument document = ParseDocument(msgPack);
-
-            if (document.FileVersion < parseLayerVersion)
-            {
-                ParseLayers(ref document, stream);
-            }
-
-            return document;
+            ParseLayers(ref document, stream);
         }
 
-        /// <summary>
-        /// Deserializes to a <see cref="SerializableDocument"/>.
-        /// </summary>
-        /// <returns>The deserialized Document.</returns>
-        public static SerializableDocument Deserialize(byte[] bytes) => Deserialize(new MemoryStream(bytes));
+        return document;
+    }
 
-        /// <summary>
-        /// Deserializes a .pixi file to a <see cref="SerializableDocument"/>
-        /// </summary>
-        /// <param name="path">The path to the .pixi file</param>
-        /// <returns>The deserialized document.</returns>
-        public static SerializableDocument Deserialize(string path)
+    /// <summary>
+    /// Deserializes to a <see cref="SerializableDocument"/>.
+    /// </summary>
+    /// <returns>The deserialized Document.</returns>
+    public static SerializableDocument Deserialize(byte[] bytes) => Deserialize(new MemoryStream(bytes));
+
+    /// <summary>
+    /// Deserializes a .pixi file to a <see cref="SerializableDocument"/>
+    /// </summary>
+    /// <param name="path">The path to the .pixi file</param>
+    /// <returns>The deserialized document.</returns>
+    public static SerializableDocument Deserialize(string path)
+    {
+        using FileStream stream = new(path, FileMode.Open, FileAccess.Read);
+
+        return Deserialize(stream);
+    }
+
+    private static void ThrowIfOldFormat(Stream stream)
+    {
+        if (!stream.CanSeek || stream.Length <= 44)
         {
-            using FileStream stream = new(path, FileMode.Open, FileAccess.Read);
-
-            return Deserialize(stream);
+            return;
         }
 
-        private static void ThrowIfOldFormat(Stream stream)
-        {
-            if (!stream.CanSeek || stream.Length <= 44)
-            {
-                return;
-            }
+        stream.Position += 22;
 
-            stream.Position += 22;
-
-            byte[] buffer = new byte[8];
+        byte[] buffer = new byte[8];
 
 #if NET5_0_OR_GREATER
             stream.Read(buffer);
 #else
-            stream.Read(buffer, 0, 8);
+        stream.Read(buffer, 0, 8);
 #endif
 
-            stream.Position -= 22 + 8;
+        stream.Position -= 22 + 8;
 
-            if (buffer.SequenceEqual(oldFormatIdentifier))
-            {
-                throw new OldFileFormatException();
-            }
-        }
-
-        private static byte[] GetMessagePack(Stream stream, out int bytesRead)
+        if (buffer.SequenceEqual(oldFormatIdentifier))
         {
-            byte[] lengthBytes = new byte[4];
+            throw new OldFileFormatException();
+        }
+    }
+
+    private static byte[] GetMessagePack(Stream stream, out int bytesRead)
+    {
+        byte[] lengthBytes = new byte[4];
 
 #if NET5_0_OR_GREATER
             stream.Read(lengthBytes);
             int length = BitConverter.ToInt32(lengthBytes);
 #else
-            stream.Read(lengthBytes, 0, 4);
-            int length = BitConverter.ToInt32(lengthBytes, 0);
+        stream.Read(lengthBytes, 0, 4);
+        int length = BitConverter.ToInt32(lengthBytes, 0);
 #endif
-            byte[] buffer = new byte[length];
+        byte[] buffer = new byte[length];
 
 #if NET5_0_OR_GREATER
             int read = stream.Read(buffer);
 #else
-            int read = stream.Read(buffer, 0, buffer.Length);
+        int read = stream.Read(buffer, 0, buffer.Length);
 #endif
 
-            bytesRead = read + 4;
+        bytesRead = read + 4;
 
-            if (read != length)
-            {
-                throw new InvalidFileException("Stream size did not match document size");
-            }
-
-            return buffer;
+        if (read != length)
+        {
+            throw new InvalidFileException("Stream size did not match document size");
         }
 
-        private static SerializableDocument ParseDocument(byte[] messagePack)
+        return buffer;
+    }
+
+    private static SerializableDocument ParseDocument(byte[] messagePack)
+    {
+        try
         {
+            return MessagePackSerializer.Deserialize<SerializableDocument>(
+                messagePack,
+                MessagePack.Resolvers.StandardResolverAllowPrivate.Options
+                    .WithSecurity(MessagePackSecurity.UntrustedData));
+        }
+        catch (MessagePackSerializationException e)
+        {
+            throw new InvalidFileException("Message Pack could not be deserialized", e);
+        }
+    }
+
+    private static void ParseLayers(ref SerializableDocument document, Stream stream)
+    {
+        foreach (SerializableLayer layer in document)
+        {
+            byte[] layerLength = new byte[4];
+            stream.Read(layerLength, 0, 4);
+            int layerLengthI = BitConverter.ToInt32(layerLength, 0);
+
+            if (layerLengthI == 0)
+            {
+                continue;
+            }
+
             try
             {
-                return MessagePackSerializer.Deserialize<SerializableDocument>(
-                    messagePack,
-                    MessagePack.Resolvers.StandardResolverAllowPrivate.Options
-                        .WithSecurity(MessagePackSecurity.UntrustedData));
+                layer.PngBytes = new byte[layerLengthI];
+                stream.Read(layer.PngBytes, 0, layerLengthI);
             }
-            catch (MessagePackSerializationException e)
+            catch (InvalidFileException)
             {
-                throw new InvalidFileException("Message Pack could not be deserialized", e);
-            }
-        }
-
-        private static void ParseLayers(ref SerializableDocument document, Stream stream)
-        {
-            foreach (SerializableLayer layer in document)
-            {
-                byte[] layerLength = new byte[4];
-                stream.Read(layerLength, 0, 4);
-                int layerLengthI = BitConverter.ToInt32(layerLength, 0);
-
-                if (layerLengthI == 0)
-                {
-                    continue;
-                }
-
-                try
-                {
-                    layer.PngBytes = new byte[layerLengthI];
-                    stream.Read(layer.PngBytes, 0, layerLengthI);
-                }
-                catch (InvalidFileException)
-                {
-                    throw new InvalidFileException($"Parsing png bytes from layer ('{layer.Name}') failed");
-                }
+                throw new InvalidFileException($"Parsing png bytes from layer ('{layer.Name}') failed");
             }
         }
     }

--- a/src/PixiParser/Parser/PixiParser.Serialize.cs
+++ b/src/PixiParser/Parser/PixiParser.Serialize.cs
@@ -2,66 +2,65 @@
 using System;
 using System.IO;
 
-namespace PixiEditor.Parser
-{
-    public static partial class PixiParser
-    {
-        /// <summary>
-        /// Serializes a <see cref="SerializableDocument"/> into bytes and saves them into a stream.
-        /// </summary>
-        /// <param name="document">The document to serialize.</param>
-        /// <returns>The total number of bytes written to the stream.</returns>
-        public static int Serialize(SerializableDocument document, Stream stream)
-        {
-            document.FileVersion = FileVersion;
+namespace PixiEditor.Parser;
 
-            byte[] messagePack = MessagePackSerializer.Serialize(document, MessagePack.Resolvers.StandardResolverAllowPrivate.Options);
+public static partial class PixiParser
+{
+    /// <summary>
+    /// Serializes a <see cref="SerializableDocument"/> into bytes and saves them into a stream.
+    /// </summary>
+    /// <param name="document">The document to serialize.</param>
+    /// <returns>The total number of bytes written to the stream.</returns>
+    public static int Serialize(SerializableDocument document, Stream stream)
+    {
+        document.FileVersion = FileVersion;
+
+        byte[] messagePack = MessagePackSerializer.Serialize(document, MessagePack.Resolvers.StandardResolverAllowPrivate.Options);
 
 #if NET5_0_OR_GREATER
             stream.Write(BitConverter.GetBytes(messagePack.Length));
             stream.Write(messagePack);
 #else
-            stream.Write(BitConverter.GetBytes(messagePack.Length), 0, 4);
-            stream.Write(messagePack, 0, messagePack.Length);
+        stream.Write(BitConverter.GetBytes(messagePack.Length), 0, 4);
+        stream.Write(messagePack, 0, messagePack.Length);
 #endif
 
-            return messagePack.Length + 4;
-        }
+        return messagePack.Length + 4;
+    }
 
-        /// <summary>
-        /// Serializes a <see cref="SerializableDocument"/> into bytes.
-        /// </summary>
-        /// <param name="document">The document to serialize.</param>
-        /// <returns>The serialized bytes.</returns>
-        public static byte[] Serialize(SerializableDocument document)
-        {
-            MemoryStream stream = new();
+    /// <summary>
+    /// Serializes a <see cref="SerializableDocument"/> into bytes.
+    /// </summary>
+    /// <param name="document">The document to serialize.</param>
+    /// <returns>The serialized bytes.</returns>
+    public static byte[] Serialize(SerializableDocument document)
+    {
+        MemoryStream stream = new();
 
-            Serialize(document, stream);
+        Serialize(document, stream);
 
-            stream.Seek(0, SeekOrigin.Begin);
+        stream.Seek(0, SeekOrigin.Begin);
 
-            byte[] buffer = new byte[stream.Length];
+        byte[] buffer = new byte[stream.Length];
 
 #if NET5_0_OR_GREATER
             stream.Read(buffer);
 #else
-            stream.Read(buffer, 0, buffer.Length);
+        stream.Read(buffer, 0, buffer.Length);
 #endif
 
-            return buffer;
-        }
+        return buffer;
+    }
 
-        /// <summary>
-        /// Serializes a <see cref="SerializableDocument"/> and saves it in a file.
-        /// </summary>
-        /// <param name="document">The document to serialize.</param>
-        /// <returns>The total number of bytes written to the file.</returns>
-        public static int Serialize(SerializableDocument document, string path)
-        {
-            using FileStream stream = new(path, FileMode.Create, FileAccess.Write);
+    /// <summary>
+    /// Serializes a <see cref="SerializableDocument"/> and saves it in a file.
+    /// </summary>
+    /// <param name="document">The document to serialize.</param>
+    /// <returns>The total number of bytes written to the file.</returns>
+    public static int Serialize(SerializableDocument document, string path)
+    {
+        using FileStream stream = new(path, FileMode.Create, FileAccess.Write);
 
-            return Serialize(document, stream);
-        }
+        return Serialize(document, stream);
     }
 }

--- a/src/PixiParser/Parser/PixiParser.cs
+++ b/src/PixiParser/Parser/PixiParser.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 
-namespace PixiEditor.Parser
+namespace PixiEditor.Parser;
+
+public partial class PixiParser
 {
-    public partial class PixiParser
-    {
-        public static Version FileVersion { get; } = new(3, 0, 0, 0);
-    }
+    public static Version FileVersion { get; } = new(3, 0, 0, 0);
 }

--- a/src/PixiParser/PixiParser.csproj
+++ b/src/PixiParser/PixiParser.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>Latest</LangVersion>
     <RootNamespace>PixiEditor.Parser</RootNamespace>
     <PackageId>PixiEditor.Parser</PackageId>


### PR DESCRIPTION
Resolve #10
Add `.editorconfig`

The tests run fine, though I haven't tested it with PixiEditor (I don't see why it'd fail anyway.)