### PR TITLE
.NET 8 and serializer data

### DIFF
--- a/src/PixiParser.Benchmarks/PixiParser.Benchmarks.csproj
+++ b/src/PixiParser.Benchmarks/PixiParser.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>Latest</LangVersion>
     <RootNamespace>PixiEditor.Parser.Benchmarks</RootNamespace>
   </PropertyGroup>

--- a/src/PixiParser.Skia/PixiParser.Skia.csproj
+++ b/src/PixiParser.Skia/PixiParser.Skia.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>PixiEditor.Parser.Skia</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/PixiParser.Tests/PixiParser.Tests.csproj
+++ b/src/PixiParser.Tests/PixiParser.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/PixiParser/Models/Document.cs
+++ b/src/PixiParser/Models/Document.cs
@@ -11,48 +11,44 @@ namespace PixiEditor.Parser;
 [DebuggerDisplay("{DebuggerDisplay,nq}")]
 public sealed class Document : IPixiDocument
 {
-    [IgnoreMember]
-    private string DebuggerDisplay => $"{Width}x{Height}, {Graph.AllNodes.Count()} nodes";
-    
-    [IgnoreMember]
-    private ColorCollection swatches;
-    [IgnoreMember]
-    private ColorCollection palette;
-    
+    [IgnoreMember] private string DebuggerDisplay => $"{Width}x{Height}, {Graph.AllNodes.Count()} nodes";
+
+    [IgnoreMember] private ColorCollection swatches;
+    [IgnoreMember] private ColorCollection palette;
+
     /// <summary>
     /// The .pixi version of this document
     /// </summary>
     [IgnoreMember]
     public Version Version { get; internal set; }
-    
+
     /// <summary>
     /// The minimum .pixi version required to parse this document
     /// </summary>
     [IgnoreMember]
     public Version MinVersion { get; internal set; }
-    
-    [IgnoreMember]
-    public byte[] PreviewImage { get; set; }
-    
+
+    [IgnoreMember] public byte[] PreviewImage { get; set; }
+
     /// <summary>
     /// The width of the doucment
     /// </summary>
     [Key(0)]
     public int Width { get; set; }
-    
+
     /// <summary>
     /// The height of the document
     /// </summary>
     [Key(1)]
     public int Height { get; set; }
-    
+
     [Key(2)]
     internal ColorCollection SwatchesInternal
     {
         get => swatches;
         set => swatches = value;
     }
-    
+
     [Key(3)]
     internal ColorCollection PaletteInternal
     {
@@ -77,19 +73,19 @@ public sealed class Document : IPixiDocument
         init => palette = value;
 #endif
     }
-    
-    [Key(4)]
-    public NodeGraph Graph { get; set; }
-    
-    [Key(5)]
-    public ReferenceLayer ReferenceLayer { get; set; }
-    
-    [Key(6)]
-    public AnimationData AnimationData { get; set; }
 
-    [Key(7)] 
-    public string ImageEncoderUsed { get; set; } = "PNG";
-    
+    [Key(4)] public NodeGraph Graph { get; set; }
+
+    [Key(5)] public ReferenceLayer ReferenceLayer { get; set; }
+
+    [Key(6)] public AnimationData AnimationData { get; set; }
+
+    [Key(7)] public string ImageEncoderUsed { get; set; } = "PNG";
+
+    [Key(8)] public string SerializerName { get; set; }
+
+    [Key(9)] public string SerializerVersion { get; set; }
+
 
     private ColorCollection GetColorCollection(ref ColorCollection variable)
     {

--- a/src/PixiParser/PixiParser.csproj
+++ b/src/PixiParser/PixiParser.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <LangVersion>Latest</LangVersion>
     <RootNamespace>PixiEditor.Parser</RootNamespace>
     <PackageId>PixiEditor.Parser</PackageId>


### PR DESCRIPTION
Reverted to .NET 8 to match PixiEditor .NET version and Added serializer data (what serialized .pixi file and what version, ex. PixiEditor 2.0.0.27)